### PR TITLE
Add Frontend Proctoring Provider Specific Defaults for Exam Settings

### DIFF
--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -93,7 +93,7 @@ function ExamSettings(props) {
       </ValidationFormGroup>
       <ValidationFormGroup
         for="allowingOptingOut"
-        helpText="If selected, learners can choose to take proctored exams without proctoring. If not selected, all learners must take the exam with proctoring."
+        helpText="If checked, learners can choose to take proctored exams without proctoring. If not checked, all learners must take the exam with proctoring."
       >
         <CheckBox
           id="allowingOptingOut"

--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -25,11 +25,18 @@ function ExamSettings(props) {
   }
 
   function onCreateZendeskTicketsChange(event) {
-    setAllowOptingOut(event);
+    setCreateZendeskTickets(event);
   }
 
   function onProctoringProviderChange(event) {
-    setProctoringProvider(event.target.value);
+    const provider = event.target.value;
+    setProctoringProvider(provider);
+
+    if (provider === 'proctortrack') {
+      setCreateZendeskTickets(false);
+    } else if (provider === 'software_secure') {
+      setCreateZendeskTickets(true);
+    }
   }
 
   function onProctortrackEscalationEmailChange(event) {
@@ -86,7 +93,7 @@ function ExamSettings(props) {
       </ValidationFormGroup>
       <ValidationFormGroup
         for="allowingOptingOut"
-        helpText="If checked, learners can choose to take proctored exams without proctoring. If not checked, all learners must take the exam with proctoring."
+        helpText="If selected, learners can choose to take proctored exams without proctoring. If not selected, all learners must take the exam with proctoring."
       >
         <CheckBox
           id="allowingOptingOut"

--- a/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
@@ -8,18 +8,19 @@ const defaultProps = {
 };
 
 describe('ProctoredExamSettings', () => {
-  it('updates settings based on proctoring provider', () => {
-    const component = mount(<ProctoredExamSettings {...defaultProps} />);
+  const component = mount(<ProctoredExamSettings {...defaultProps} />);
 
-    // confirm that changing proctoring provider to proctortrack changes zendesk ticket field
+  it('updates zendesk ticket field if proctortrack is provider', () => {
     component.find('select#proctoringProvider').simulate('change', { target: { value: 'proctortrack' } });
     expect(component.find('input#createZendeskTickets').prop('checked')).toEqual(false);
+  });
 
-    // confirm that changing proctoring provider to software_secure changes zendesk ticket field
+  it('updates zendesk ticket field if software_secure is provider', () => {
     component.find('select#proctoringProvider').simulate('change', { target: { value: 'software_secure' } });
     expect(component.find('input#createZendeskTickets').prop('checked')).toEqual(true);
+  });
 
-    // confirm that changing proctoring provider to any other provider does not change zendesk ticket field
+  it('does not update zendesk ticket field for any other provider', () => {
     component.find('select#proctoringProvider').simulate('change', { target: { value: 'mockprock' } });
     expect(component.find('input#createZendeskTickets').prop('checked')).toEqual(true);
   });

--- a/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ProctoredExamSettings from './ProctoredExamSettings';
+
+const defaultProps = {
+  courseId: 'course-v1%3AedX%2BDemoX%2BDemo_Course',
+};
+
+describe('ProctoredExamSettings', () => {
+  it('updates settings based on proctoring provider', () => {
+    const component = mount(<ProctoredExamSettings {...defaultProps} />);
+
+    // confirm that changing proctoring provider to proctortrack changes zendesk ticket field
+    component.find('select#proctoringProvider').simulate('change', { target: { value: 'proctortrack' } });
+    expect(component.find('input#createZendeskTickets').prop('checked')).toEqual(false);
+
+    // confirm that changing proctoring provider to software_secure changes zendesk ticket field
+    component.find('select#proctoringProvider').simulate('change', { target: { value: 'software_secure' } });
+    expect(component.find('input#createZendeskTickets').prop('checked')).toEqual(true);
+
+    // confirm that changing proctoring provider to any other provider does not change zendesk ticket field
+    component.find('select#proctoringProvider').simulate('change', { target: { value: 'mockprock' } });
+    expect(component.find('input#createZendeskTickets').prop('checked')).toEqual(true);
+  });
+});

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,1 +1,11 @@
 import 'babel-polyfill';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import axios from 'axios';
+import { getAuthenticatedHttpClient, getAuthenticatedUser } from '@edx/frontend-platform/auth';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+jest.mock('@edx/frontend-platform/auth');
+getAuthenticatedHttpClient.mockReturnValue(axios);
+getAuthenticatedUser.mockReturnValue({ administrator: false });


### PR DESCRIPTION
## [MST-293](https://openedx.atlassian.net/browse/MST-293)

- Sets “Create Zendesk tickets for suspicious proctored exam attempts” to 'false' by default if “proctortrack” is selected as proctoring provider. 

- Sets “Create Zendesk tickets for suspicious proctored exam attempts” to 'true' by default if “software_secure” is selected as proctoring provider. 