### PR TITLE
MST-335 Hide the Proctortrack Escalation Email field if the Provider backend is not Proctortrack

### DIFF
--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -27,6 +27,7 @@ function ExamSettings(props) {
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState(false);
   const [submissionInProgress, setSubmissionInProgress] = useState(false);
+  const [showProctortrackEscalationEmail, setShowProctortrackEscalationEmail] = useState(false);
 
   function onEnableProctoredExamsChange(event) {
     setEnableProctoredExams(event.target.checked);
@@ -46,8 +47,13 @@ function ExamSettings(props) {
 
     if (provider === 'proctortrack') {
       setCreateZendeskTickets(false);
-    } else if (provider === 'software_secure') {
-      setCreateZendeskTickets(true);
+      setShowProctortrackEscalationEmail(true);
+    } else {
+      if (provider === 'software_secure') {
+        setCreateZendeskTickets(true);
+      }
+      setProctortrackEscalationEmail('');
+      setShowProctortrackEscalationEmail(false);
     }
   }
 
@@ -192,22 +198,24 @@ function ExamSettings(props) {
         </Form.Group>
 
         {/* PROCTORTRACK ESCALATION EMAIL */}
-        <Form.Group controlId="formProctortrackEscalationEmail">
-          <Form.Label>Proctortrack Escalation Email</Form.Label>
-          <Form.Control
-            type="email"
-            data-test-id="escalationEmail"
-            onChange={onProctortrackEscalationEmailChange}
-            value={proctortrackEscalationEmail}
-            isInvalid={!!proctortrackEscalationEmailError}
-          />
-          <Form.Control.Feedback type="invalid">{proctortrackEscalationEmailError}</Form.Control.Feedback>
-          <Form.Text>
-            Required if &quot;proctortrack&quot; is selected as your proctoring provider.
-            Enter an email address to be contacted by the support team whenever there are escalations
-            (e.g. appeals, delayed reviews, etc.).
-          </Form.Text>
-        </Form.Group>
+        {showProctortrackEscalationEmail && (
+          <Form.Group controlId="formProctortrackEscalationEmail">
+            <Form.Label>Proctortrack Escalation Email</Form.Label>
+            <Form.Control
+              type="email"
+              data-test-id="escalationEmail"
+              onChange={onProctortrackEscalationEmailChange}
+              value={proctortrackEscalationEmail}
+              isInvalid={!!proctortrackEscalationEmailError}
+            />
+            <Form.Control.Feedback type="invalid">{proctortrackEscalationEmailError}</Form.Control.Feedback>
+            <Form.Text>
+              Required if &quot;proctortrack&quot; is selected as your proctoring provider.
+              Enter an email address to be contacted by the support team whenever there are escalations
+              (e.g. appeals, delayed reviews, etc.).
+            </Form.Text>
+          </Form.Group>
+        )}
 
         {/* CREATE ZENDESK TICKETS */}
         <fieldset aria-describedby="allowOptingOutHelpText">
@@ -331,6 +339,8 @@ function ExamSettings(props) {
             setEnableProctoredExams(proctoredExamSettings.enable_proctored_exams);
             setAllowOptingOut(proctoredExamSettings.allow_proctoring_opt_out);
             setProctoringProvider(proctoredExamSettings.proctoring_provider);
+            const isProctortrack = proctoredExamSettings.proctoring_provider === 'proctortrack';
+            setShowProctortrackEscalationEmail(isProctortrack);
             setAvailableProctoringProviders(response.data.available_proctoring_providers);
             setProctortrackEscalationEmail(proctoredExamSettings.proctoring_escalation_email);
             setCreateZendeskTickets(proctoredExamSettings.create_zendesk_tickets);

--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -52,7 +52,6 @@ function ExamSettings(props) {
       if (provider === 'software_secure') {
         setCreateZendeskTickets(true);
       }
-      setProctortrackEscalationEmail('');
       setShowProctortrackEscalationEmail(false);
     }
   }

--- a/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
@@ -177,7 +177,7 @@ describe('ProctoredExamSettings tests with escalation email', () => {
     });
     expect(screen.queryByTestId('escalationEmail')).toBeDefined();
     selectEscalationEmailElement = screen.getByTestId('escalationEmail');
-    expect(selectEscalationEmailElement.value).toEqual('');
+    expect(selectEscalationEmailElement.value).toEqual('test@example.com');
   });
 });
 

--- a/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
@@ -74,7 +74,7 @@ describe('ProctoredExamSettings check default on create zendesk ticket field tes
   });
 });
 
-describe('ProctoredExamSettings alert with invalid escalation email', () => {
+describe('ProctoredExamSettings tests with escalation email', () => {
   beforeEach(async () => {
     auth.getAuthenticatedHttpClient = jest.fn(() => ({
       get: async () => ({
@@ -89,8 +89,8 @@ describe('ProctoredExamSettings alert with invalid escalation email', () => {
           available_proctoring_providers: ['software_secure', 'proctortrack', 'mockproc'],
           course_start_date: '2070-01-01T00:00:00Z',
         },
-        catch: () => {},
       }),
+      post: async () => ({}),
     }));
 
     auth.getAuthenticatedUser = jest.fn(() => ({ userId: 3, administrator: false }));
@@ -147,6 +147,37 @@ describe('ProctoredExamSettings alert with invalid escalation email', () => {
     });
     const escalationEmailError = screen.queryByTestId('proctortrackEscalationEmailError');
     expect(escalationEmailError).toBeNull();
+  });
+
+  it('Escalation Email field hidden when proctoring backend is not Proctortrack', async () => {
+    await waitFor(() => {
+      screen.getByDisplayValue('proctortrack');
+    });
+    const proctoringBackendSelect = screen.getByDisplayValue('proctortrack');
+    const selectEscalationEmailElement = screen.getByTestId('escalationEmail');
+    expect(selectEscalationEmailElement.value).toEqual('test@example.com');
+    await act(async () => {
+      fireEvent.change(proctoringBackendSelect, { target: { value: 'software_secure' } });
+    });
+    expect(screen.queryByTestId('escalationEmail')).toBeNull();
+  });
+
+  it('Escalation Email Field Show when proctoring backend is switched back to Proctortrack', async () => {
+    await waitFor(() => {
+      screen.getByDisplayValue('proctortrack');
+    });
+    const proctoringBackendSelect = screen.getByDisplayValue('proctortrack');
+    let selectEscalationEmailElement = screen.getByTestId('escalationEmail');
+    await act(async () => {
+      fireEvent.change(proctoringBackendSelect, { target: { value: 'software_secure' } });
+    });
+    expect(screen.queryByTestId('escalationEmail')).toBeNull();
+    await act(async () => {
+      fireEvent.change(proctoringBackendSelect, { target: { value: 'proctortrack' } });
+    });
+    expect(screen.queryByTestId('escalationEmail')).toBeDefined();
+    selectEscalationEmailElement = screen.getByTestId('escalationEmail');
+    expect(selectEscalationEmailElement.value).toEqual('');
   });
 });
 


### PR DESCRIPTION
@edx/masters-devs-cosmonauts Pleas review.

This is the PR to hide the Proctortrack Escalation Email field if the backend is not proctortrack.