### PR TITLE
Discussion tool selection page skeleton

### DIFF
--- a/src/CourseAuthoringRoutes.jsx
+++ b/src/CourseAuthoringRoutes.jsx
@@ -6,6 +6,7 @@ import { PageRoute } from '@edx/frontend-platform/react';
 import CourseAuthoringPage from './CourseAuthoringPage';
 import { CoursePageResources } from './course-page-resources';
 import ProctoredExamSettings from './proctored-exam-settings/ProctoredExamSettings';
+import DiscussionToolSelectorContainer from './discussion-tool-selector/DiscussionToolSelectorContainer';
 
 /**
  * As of this writing, these routes are mounted at a path prefixed with the following:
@@ -27,8 +28,11 @@ export default function CourseAuthoringRoutes({ courseId }) {
   return (
     <CourseAuthoringPage courseId={courseId}>
       <Switch>
-        <PageRoute path={`${path}/pages`}>
+        <PageRoute exact path={`${path}/pages`}>
           <CoursePageResources courseId={courseId} />
+        </PageRoute>
+        <PageRoute path={`${path}/pages/discussion`}>
+          <DiscussionToolSelectorContainer courseId={courseId} />
         </PageRoute>
         <PageRoute path={`${path}/proctored-exam-settings`}>
           <ProctoredExamSettings courseId={courseId} />

--- a/src/discussion-tool-selector/DiscussionToolSelector.scss
+++ b/src/discussion-tool-selector/DiscussionToolSelector.scss
@@ -1,0 +1,16 @@
+.discussion-tool {
+    &:hover,
+    &:focus {
+        border-color: theme-color("primary", "hover") !important;
+    }
+}
+
+.features-table {
+    scroll-snap-type: x mandatory;
+
+    th {
+        min-width: 7.5rem;
+        white-space: nowrap;
+        scroll-snap-align: center;
+    }
+}

--- a/src/discussion-tool-selector/DiscussionToolSelector.test.jsx
+++ b/src/discussion-tool-selector/DiscussionToolSelector.test.jsx
@@ -1,0 +1,5 @@
+describe('example', () => {
+  it('will pass because it is an example', () => {
+
+  });
+});

--- a/src/discussion-tool-selector/DiscussionToolSelectorContainer.jsx
+++ b/src/discussion-tool-selector/DiscussionToolSelectorContainer.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import DiscussionToolSelector from './discussion-tool-selector/DiscussionToolSelector';
+
+// XXX this is just for testing and should be removed ASAP
+const forums = [
+  {
+    forumId: 'edX Forum',
+    logo: 'https://cdn-blog.lawrencemcdaniel.com/wp-content/uploads/2018/01/22125436/edx-logo.png',
+    description: 'Start conversations with other learners, ask questions, and interact with other learners in the course.',
+    supportLevel: 'Full support',
+    isAvailable: true,
+    features: ['LTI Integration', 'Discussion Page', 'Embedded Course Sections', 'Embedded Course Units', 'WCAG 2.1 Support'],
+  },
+  {
+    forumId: 'Piazza',
+    logo: 'https://cdn-blog.lawrencemcdaniel.com/wp-content/uploads/2018/01/22125436/edx-logo.png',
+    description: 'Piazza is designed to connect students, TAs, and professors so every student can get the help they need when they need it',
+    supportLevel: 'Partial support',
+    isAvailable: true,
+    features: ['LTI Integration', 'Discussion Page', 'Embedded Course Sections', 'WCAG 2.1 Support'],
+  },
+  {
+    forumId: 'Yellowdig',
+    logo: 'https://cdn-blog.lawrencemcdaniel.com/wp-content/uploads/2018/01/22125436/edx-logo.png',
+    description: 'Yellowdig is the digital solution that impacts the entire student lifecycle and enables lifelong learning.',
+    supportLevel: 'Coming soon',
+    isAvailable: false,
+    features: ['LTI Integration', 'Discussion Page', 'Embedded Course Sections', 'WCAG 2.1 Support'],
+  },
+  {
+    forumId: 'Untitled Forum',
+    logo: 'https://cdn-blog.lawrencemcdaniel.com/wp-content/uploads/2018/01/22125436/edx-logo.png',
+    description: 'Start conversations with other learners, ask questions, and interact with other learners in the course.',
+    supportLevel: 'Full support',
+    isAvailable: true,
+    features: ['LTI Integration', 'Discussion Page', 'Embedded Course Sections', 'Embedded Course Units', 'WCAG 2.1 Support'],
+  },
+];
+
+const featuresList = ['LTI Integration', 'Discussion Page', 'Embedded Course Sections', 'Embedded Course Units', 'WCAG 2.1 Support'];
+
+function DiscussionToolSelectorContainer({ intl }) {
+  const [selectedForumId, setSelectedForumId] = useState(null);
+
+  const onSelectForum = (forumId) => {
+    setSelectedForumId(forumId);
+  };
+
+  return (
+    <DiscussionToolSelector
+      intl={intl}
+      forums={forums}
+      featuresList={featuresList}
+      onSelectForum={onSelectForum}
+      selectedForumId={selectedForumId}
+    />
+  );
+}
+
+DiscussionToolSelectorContainer.propTypes = {
+  intl: intlShape.isRequired,
+};
+
+export default injectIntl(DiscussionToolSelectorContainer);

--- a/src/discussion-tool-selector/DiscussionToolSelectorContainer.jsx
+++ b/src/discussion-tool-selector/DiscussionToolSelectorContainer.jsx
@@ -44,7 +44,11 @@ function DiscussionToolSelectorContainer({ intl }) {
   const [selectedForumId, setSelectedForumId] = useState(null);
 
   const onSelectForum = (forumId) => {
-    setSelectedForumId(forumId);
+    if (selectedForumId === forumId) {
+      setSelectedForumId(null);
+    } else {
+      setSelectedForumId(forumId);
+    }
   };
 
   return (

--- a/src/discussion-tool-selector/discussion-tool-selector/DiscussionToolSelector.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/DiscussionToolSelector.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Container, Row } from '@edx/paragon';
+import PropTypes from 'prop-types';
+import DiscussionToolOption from './discussion-tool-option/DiscussionToolOption';
+import FeaturesTable from './features-table/FeaturesTable';
+import messages from '../messages';
+
+function DiscussionToolSelector({
+  intl, forums, featuresList, onSelectForum, selectedForumId,
+}) {
+  return (
+    <Container fluid className="text-info-300">
+      <h6 className="my-4 text-center">{intl.formatMessage(messages.heading)}</h6>
+
+      <Row>
+        {forums.map(forum => (
+          <DiscussionToolOption
+            key={forum.forumId}
+            forum={forum}
+            selected={forum.forumId === selectedForumId}
+            onSelect={onSelectForum}
+          />
+        ))}
+      </Row>
+
+      <h2 className="my-3">{intl.formatMessage(messages.supportedFeatures)}</h2>
+
+      <FeaturesTable forums={forums} featuresList={featuresList} />
+    </Container>
+  );
+}
+
+DiscussionToolSelector.propTypes = {
+  intl: intlShape.isRequired,
+  forums: PropTypes.arrayOf(PropTypes.object).isRequired,
+  featuresList: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onSelectForum: PropTypes.func.isRequired,
+  selectedForumId: PropTypes.string.isRequired,
+};
+
+export default injectIntl(DiscussionToolSelector);

--- a/src/discussion-tool-selector/discussion-tool-selector/DiscussionToolSelector.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/DiscussionToolSelector.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Container, Row } from '@edx/paragon';
+import { Button, Container, Row } from '@edx/paragon';
 import PropTypes from 'prop-types';
 import DiscussionToolOption from './discussion-tool-option/DiscussionToolOption';
 import FeaturesTable from './features-table/FeaturesTable';
@@ -24,7 +24,16 @@ function DiscussionToolSelector({
         ))}
       </Row>
 
-      <h2 className="my-3">{intl.formatMessage(messages.supportedFeatures)}</h2>
+      <div className="d-flex justify-content-between align-items-center">
+        <h2 className="my-3">
+          {intl.formatMessage(messages.supportedFeatures)}
+        </h2>
+        {selectedForumId && (
+          <Button variant="primary">
+            {intl.formatMessage(messages.configureTool, { toolName: selectedForumId })}
+          </Button>
+        )}
+      </div>
 
       <FeaturesTable forums={forums} featuresList={featuresList} />
     </Container>

--- a/src/discussion-tool-selector/discussion-tool-selector/DiscussionToolSelector.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/DiscussionToolSelector.jsx
@@ -10,7 +10,7 @@ function DiscussionToolSelector({
   intl, forums, featuresList, onSelectForum, selectedForumId,
 }) {
   return (
-    <Container fluid className="text-info-300">
+    <Container fluid className="text-info-500">
       <h6 className="my-4 text-center">{intl.formatMessage(messages.heading)}</h6>
 
       <Row>

--- a/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
@@ -3,9 +3,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { CheckBox, Image, Col } from '@edx/paragon';
 import { faLock } from '@fortawesome/free-solid-svg-icons';
 import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
-export default function DiscussionToolOption({
-  forum, selected, onSelect,
+import messages from '../../messages';
+
+function DiscussionToolOption({
+  intl, forum, selected, onSelect,
 }) {
   return (
     <Col className="mb-4" xs={12} sm={6} lg={4} xl={3}>
@@ -22,7 +25,13 @@ export default function DiscussionToolOption({
       >
         <div className="d-flex flex-row justify-content-between">
           <div className="d-flex justify-content-center">
-            <Image height={100} src={forum.logo} alt="Logo" />
+            <Image
+              height={100}
+              src={forum.logo}
+              alt={intl.formatMessage(messages.toolLogo, {
+                toolName: forum.forumId,
+              })}
+            />
           </div>
           <div className="d-flex">
             {forum.isAvailable ? (
@@ -42,7 +51,10 @@ export default function DiscussionToolOption({
 }
 
 DiscussionToolOption.propTypes = {
+  intl: intlShape.isRequired,
   forum: PropTypes.objectOf(PropTypes.any).isRequired,
   selected: PropTypes.bool.isRequired,
   onSelect: PropTypes.func.isRequired,
 };
+
+export default injectIntl(DiscussionToolOption);

--- a/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { CheckBox, Image, Col } from '@edx/paragon';
+import { faLock } from '@fortawesome/free-solid-svg-icons';
+import PropTypes from 'prop-types';
+
+export default function DiscussionToolOption({
+  forum, selected, onSelect,
+}) {
+  return (
+    <Col className="mb-4" xs={12} sm={6} lg={4} xl={3}>
+      <div
+        className="d-flex discussion-tool flex-column p-3 h-100 shadow border border-white"
+        tabIndex={forum.isAvailable ? '-1' : ''}
+        onClick={() => { if (forum.isAvailable) { onSelect(forum.forumId); } }}
+        onKeyPress={() => { if (forum.isAvailable) { onSelect(forum.forumId); } }}
+        role="radio"
+        aria-checked={selected}
+      >
+        <div className="d-flex flex-row">
+          <div className="d-flex justify-content-center"><Image fluid src={forum.logo} alt="Logo" /></div>
+          <div className="d-flex">
+            {forum.isAvailable ? (
+              <CheckBox checked={selected} />
+            ) : (
+              <FontAwesomeIcon icon={faLock} />
+            )}
+          </div>
+        </div>
+        <br />
+        <div className="py-4">{forum.description}</div>
+        <br />
+        <div className="mt-auto font-weight-bold">{forum.supportLevel}</div>
+      </div>
+    </Col>
+  );
+}
+
+DiscussionToolOption.propTypes = {
+  forum: PropTypes.objectOf(PropTypes.any).isRequired,
+  selected: PropTypes.bool.isRequired,
+  onSelect: PropTypes.func.isRequired,
+};

--- a/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
@@ -20,8 +20,10 @@ export default function DiscussionToolOption({
         role="radio"
         aria-checked={selected}
       >
-        <div className="d-flex flex-row">
-          <div className="d-flex justify-content-center"><Image fluid src={forum.logo} alt="Logo" /></div>
+        <div className="d-flex flex-row justify-content-between">
+          <div className="d-flex justify-content-center">
+            <Image height={100} src={forum.logo} alt="Logo" />
+          </div>
           <div className="d-flex">
             {forum.isAvailable ? (
               <CheckBox checked={selected} />

--- a/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/discussion-tool-option/DiscussionToolOption.jsx
@@ -11,6 +11,9 @@ export default function DiscussionToolOption({
     <Col className="mb-4" xs={12} sm={6} lg={4} xl={3}>
       <div
         className="d-flex discussion-tool flex-column p-3 h-100 shadow border border-white"
+        style={{
+          cursor: 'pointer',
+        }}
         tabIndex={forum.isAvailable ? '-1' : ''}
         onClick={() => { if (forum.isAvailable) { onSelect(forum.forumId); } }}
         onKeyPress={() => { if (forum.isAvailable) { onSelect(forum.forumId); } }}

--- a/src/discussion-tool-selector/discussion-tool-selector/features-table/FeaturesTable.jsx
+++ b/src/discussion-tool-selector/discussion-tool-selector/features-table/FeaturesTable.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+
+export default function FeaturesTable({ forums, featuresList }) {
+  return (
+    <div className="table-responsive features-table border border-info-300 p-3 mb-4">
+      <table className="w-100">
+        <thead>
+          <tr>
+            <th>&nbsp;</th>
+            {forums.map(forum => (
+              <th className="text-center py-3" key={forum.forumId}><h5>{forum.forumId}</h5></th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {featuresList.map(feature => (
+            <tr key={feature}>
+              <th key={feature} className="py-3">{feature}</th>
+              {forums.map(forum => (
+                <td className="text-center py-3" key={forum.forumId}>
+                  {forum.features.includes(feature) && <FontAwesomeIcon icon={faCheck} />}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+FeaturesTable.propTypes = {
+  forums: PropTypes.arrayOf(PropTypes.object).isRequired,
+  featuresList: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/src/discussion-tool-selector/messages.js
+++ b/src/discussion-tool-selector/messages.js
@@ -1,0 +1,14 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  heading: {
+    id: 'authoring.forumSelectorTool.heading',
+    defaultMessage: 'Which discussion tool would you like to use for this course?',
+  },
+  supportedFeatures: {
+    id: 'authoring.forumSelectorTool.supportedFeatures',
+    defaultMessage: 'Supported Features',
+  },
+});
+
+export default messages;

--- a/src/discussion-tool-selector/messages.js
+++ b/src/discussion-tool-selector/messages.js
@@ -9,6 +9,14 @@ const messages = defineMessages({
     id: 'authoring.forumSelectorTool.supportedFeatures',
     defaultMessage: 'Supported Features',
   },
+  configureTool: {
+    id: 'authoring.forumSelectorTool.configureTool',
+    defaultMessage: 'Configure {toolName}',
+  },
+  toolLogo: {
+    id: 'authoring.forumSelectorTool.toolLogo',
+    defaultMessage: '{toolName} Logo',
+  },
 });
 
 export default messages;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,6 @@ import { Route, Switch } from 'react-router-dom';
 import { messages as footerMessages } from '@edx/frontend-component-footer';
 
 import appMessages from './i18n';
-import DiscussionToolSelectorContainer from './discussion-tool-selector/DiscussionToolSelectorContainer';
 
 import initializeStore from './store';
 import './index.scss';
@@ -41,18 +40,6 @@ subscribe(APP_READY, () => {
             const { params: { courseId } } = match;
             return (
               <CourseAuthoringRoutes courseId={courseId} />
-            );
-          }}
-        />
-	<Route
-          path="/course-pages/:course_id/discussions/setup"
-          exact
-          render={({ match }) => {
-            const courseId = decodeURIComponent(match.params.course_id);
-            return (
-              <>
-                <DiscussionToolSelectorContainer courseId={courseId} />
-              </>
             );
           }}
         />

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,6 +12,7 @@ import { Route, Switch } from 'react-router-dom';
 import { messages as footerMessages } from '@edx/frontend-component-footer';
 
 import appMessages from './i18n';
+import DiscussionToolSelectorContainer from './discussion-tool-selector/DiscussionToolSelectorContainer';
 
 import initializeStore from './store';
 import './index.scss';
@@ -40,6 +41,18 @@ subscribe(APP_READY, () => {
             const { params: { courseId } } = match;
             return (
               <CourseAuthoringRoutes courseId={courseId} />
+            );
+          }}
+        />
+	<Route
+          path="/course-pages/:course_id/discussions/setup"
+          exact
+          render={({ match }) => {
+            const courseId = decodeURIComponent(match.params.course_id);
+            return (
+              <>
+                <DiscussionToolSelectorContainer courseId={courseId} />
+              </>
             );
           }}
         />

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,4 +8,7 @@
 @import "~@edx/frontend-component-footer/dist/footer";
 
 @import "proctored-exam-settings/proctoredExamSettings.scss";
+
+@import "discussion-tool-selector/DiscussionToolSelector.scss";
+
 @import "studio-header/header.scss";


### PR DESCRIPTION
This is an initial implementation of the discussion tool selection page.  It doesn't do anything yet, and can't open modals for configuring selected tools.

This incorporates commits from @aayushagra's PR here: #36. 

I've rebased it on master and tweaked the route URL scheme, then made some cursory styling tweaks and stubbed out a "Configure forums" button.  

This page will be accessible only by knowing the URL to it, so it's safe to merge to master even though it's not done.

FYI @xitij2000