### PR TITLE
Prevent frontend errors for escalation email if proctoring is disabled

### DIFF
--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -108,7 +108,7 @@ function ProctoredExamSettings({ courseId, intl }) {
 
   function handleSubmit(event) {
     event.preventDefault();
-    if (proctoringProvider === 'proctortrack' && !EmailValidator.validate(proctortrackEscalationEmail)) {
+    if (proctoringProvider === 'proctortrack' && !EmailValidator.validate(proctortrackEscalationEmail) && !(proctortrackEscalationEmail === '' && !enableProctoredExams)) {
       if (proctortrackEscalationEmail === '') {
         const errorMessage = intl.formatMessage(messages['authoring.examsettings.escalationemail.error.blank']);
 
@@ -192,7 +192,7 @@ function ProctoredExamSettings({ courseId, intl }) {
   function renderContent() {
     return (
       <Form onSubmit={handleSubmit} data-test-id="proctoringForm">
-        {enableProctoredExams && !formStatus.isValid && formStatus.errors.formProctortrackEscalationEmail
+        {!formStatus.isValid && formStatus.errors.formProctortrackEscalationEmail
           && (
             // tabIndex="-1" to make non-focusable element focusable
             <Alert

--- a/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.test.jsx
@@ -238,6 +238,53 @@ describe('ProctoredExamSettings', () => {
       expect(document.activeElement).toEqual(escalationEmailInput);
     });
 
+    it('Creates an alert when invalid proctoring escalation email is provided with proctoring disabled', async () => {
+      await waitFor(() => {
+        screen.getByDisplayValue('proctortrack');
+      });
+      const selectEscalationEmailElement = screen.getByDisplayValue('test@example.com');
+      await act(async () => {
+        fireEvent.change(selectEscalationEmailElement, { target: { value: 'foo.bar' } });
+      });
+      const enableProctoringElement = screen.getByLabelText('Enable Proctored Exams');
+      await act(async () => fireEvent.click(enableProctoringElement));
+      const selectButton = screen.getByTestId('submissionButton');
+      await act(async () => {
+        fireEvent.click(selectButton);
+      });
+
+      // verify alert content and focus management
+      const escalationEmailError = screen.getByTestId('proctortrackEscalationEmailError');
+      expect(document.activeElement).toEqual(escalationEmailError);
+      expect(escalationEmailError.textContent).not.toBeNull();
+      expect(document.activeElement).toEqual(escalationEmailError);
+    });
+
+    it('Has no error when invalid proctoring escalation email is provided with proctoring disabled', async () => {
+      await waitFor(() => {
+        screen.getByDisplayValue('proctortrack');
+      });
+      const selectEscalationEmailElement = screen.getByDisplayValue('test@example.com');
+      await act(async () => {
+        fireEvent.change(selectEscalationEmailElement, { target: { value: '' } });
+      });
+      const enableProctoringElement = screen.getByLabelText('Enable Proctored Exams');
+      await act(async () => fireEvent.click(enableProctoringElement));
+      const selectButton = screen.getByTestId('submissionButton');
+      await act(async () => {
+        fireEvent.click(selectButton);
+      });
+
+      // verify there is no escalation email alert, and focus has been set on save success alert
+      expect(screen.queryByTestId('proctortrackEscalationEmailError')).toBeNull();
+
+      const errorAlert = screen.getByTestId('saveSuccess');
+      expect(errorAlert.textContent).toEqual(
+        expect.stringContaining('Proctored exam settings saved successfully.'),
+      );
+      expect(document.activeElement).toEqual(errorAlert);
+    });
+
     it('Has no error when valid proctoring escalation email is provided with proctortrack selected', async () => {
       await waitFor(() => {
         screen.getByDisplayValue('proctortrack');


### PR DESCRIPTION
## [MST-643](https://openedx.atlassian.net/browse/MST-643)

Prevent frontend errors for invalid proctoring escalation email if proctoring is disabled. This should be merged after the [PR for backend validation](https://github.com/edx/edx-platform/pull/27166) has been merged and deployed.