### PR TITLE
fix: improve app config forms, refactor LegacyConfigForm, add tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 const { createConfig } = require('@edx/frontend-build');
 
 module.exports = createConfig('jest', {
-  setupFiles: [
+  setupFilesAfterEnv: [
     '<rootDir>/src/setupTest.js',
   ],
   coveragePathIgnorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -3507,9 +3507,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "13.13.5",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-13.13.5.tgz",
-      "integrity": "sha512-6q60Lj5dbzZbcXfNrpHXqn4tKQYf1KmcISOe//un0JTSQr6/LnZjHZoZfmzDaRX/2KEDaLCTqCefvKTpB26qCQ==",
+      "version": "13.17.3",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-13.17.3.tgz",
+      "integrity": "sha512-fUjrfNmeWIpEsroK0JuajIBHHh0BIvZTnBusTRqzvl5fFivNuhEdcG33oEZSVvfyRYtCgtnWmSRbvN5vGhjK6g==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -3535,24 +3535,24 @@
       },
       "dependencies": {
         "@fortawesome/fontawesome-common-types": {
-          "version": "0.2.34",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.34.tgz",
-          "integrity": "sha512-XcIn3iYbTEzGIxD0/dY5+4f019jIcEIWBiHc3KrmK/ROahwxmZ/s+tdj97p/5K0klz4zZUiMfUlYP0ajhSJjmA=="
+          "version": "0.2.35",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
+          "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
         },
         "@fortawesome/fontawesome-svg-core": {
-          "version": "1.2.34",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.34.tgz",
-          "integrity": "sha512-0KNN0nc5eIzaJxlv43QcDmTkDY1CqeN6J7OCGSs+fwGPdtv0yOQqRjieopBCmw+yd7uD3N2HeNL3Zm5isDleLg==",
+          "version": "1.2.35",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
+          "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
           "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.34"
+            "@fortawesome/fontawesome-common-types": "^0.2.35"
           }
         },
         "@fortawesome/free-solid-svg-icons": {
-          "version": "5.15.2",
-          "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.2.tgz",
-          "integrity": "sha512-ZfCU+QjaFsdNZmOGmfqEWhzI3JOe37x5dF4kz9GeXvKn/sTxhqMtZ7mh3lBf76SvcYY5/GKFuyG7p1r4iWMQqw==",
+          "version": "5.15.3",
+          "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
+          "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
           "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.34"
+            "@fortawesome/fontawesome-common-types": "^0.2.35"
           }
         },
         "@fortawesome/react-fontawesome": {
@@ -4812,9 +4812,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.0.tgz",
-      "integrity": "sha512-wjtKehFAIARq2OxK8j3JrggNlEslJfNuSm2ArteIbKyRMts2g0a7KzTxfRVNUM+O0gnBJ2hNV8nWPOYBgI1sew=="
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.1.tgz",
+      "integrity": "sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA=="
     },
     "@reduxjs/toolkit": {
       "version": "1.5.0",
@@ -5280,6 +5280,129 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.11.10",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.10.tgz",
+      "integrity": "sha512-FuKiq5xuk44Fqm0000Z9w0hjOdwZRNzgx7xGGxQYepWFZy+OYUMOT/wPI4nLYXCaVltNVpU1W/qmD88wLWDsqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+          "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.10.2",
+            "@babel/runtime-corejs3": "^7.10.2"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "10.4.7",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.7.tgz",
@@ -5429,6 +5552,107 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.22",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.22.tgz",
+      "integrity": "sha512-eeWwWjlqxvBxc4oQdkueW5OF/gtfSceKk4OnOAGlUSwS/liBRtZppbJuz1YkgbrbfGOoeBHun9fOvXnjNwrSOw==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
+          "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^17.0.1"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -5483,11 +5707,12 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.3.tgz",
+      "integrity": "sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==",
       "requires": {
         "@types/prop-types": "*",
+        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       },
       "dependencies": {
@@ -5505,6 +5730,11 @@
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
     "@types/schema-utils": {
       "version": "2.4.0",
@@ -5532,6 +5762,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.12.0",
@@ -8815,6 +9054,12 @@
       "integrity": "sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==",
       "dev": true
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
     "cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -9403,9 +9648,9 @@
       "dev": true
     },
     "detect-node-es": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.0.0.tgz",
-      "integrity": "sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "detect-port-alt": {
       "version": "1.1.6",
@@ -9564,9 +9809,9 @@
       }
     },
     "domutils": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.4.4.tgz",
-      "integrity": "sha512-jBC0vOsECI4OMdD0GC9mGn7NXPLb+Qt6KW1YDQzeQYRUFKmNG8lh7mO5HiELfr+lLQE7loDVI4QcAxV80HS+RA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.5.0.tgz",
+      "integrity": "sha512-Ho16rzNMOFk2fPwChGh3D2D9OEHAfG19HgmRR2l+WLSsIstNsAYBzePH412bL0y5T44ejABIVfTHQ8nqi/tBCg==",
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
@@ -11485,9 +11730,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.18.0-next.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.3.tgz",
-          "integrity": "sha512-VMzHx/Bczjg59E6jZOQjHeN3DEoptdhejpARgflAViidlqSpjdq9zA6lKwlhRRs/lOw1gHJv2xkkSFRgvEwbQg==",
+          "version": "1.18.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+          "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
@@ -18129,6 +18374,12 @@
       "dev": true,
       "optional": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "mini-create-react-context": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.3.tgz",
@@ -20696,18 +20947,18 @@
       }
     },
     "react-bootstrap": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.5.1.tgz",
-      "integrity": "sha512-jbJNGx9n4JvKgxlvT8DLKSeF3VcqnPJXS9LFdzoZusiZCCGoYecZ9qSCBH5n2A+kjmuura9JkvxI9l7HD+bIdQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.5.2.tgz",
+      "integrity": "sha512-mGKPY5+lLd7Vtkx2VFivoRkPT4xAHazuFfIhJLTEgHlDfIUSePn7qrmpZe5gXH9zvHV0RsBaQ9cLfXjxnZrOpA==",
       "requires": {
-        "@babel/runtime": "^7.4.2",
+        "@babel/runtime": "^7.13.8",
         "@restart/context": "^2.1.4",
-        "@restart/hooks": "^0.3.21",
+        "@restart/hooks": "^0.3.26",
         "@types/classnames": "^2.2.10",
         "@types/invariant": "^2.2.33",
         "@types/prop-types": "^15.7.3",
         "@types/react": ">=16.9.35",
-        "@types/react-transition-group": "^4.4.0",
+        "@types/react-transition-group": "^4.4.1",
         "@types/warning": "^3.0.0",
         "classnames": "^2.2.6",
         "dom-helpers": "^5.1.2",
@@ -20716,8 +20967,18 @@
         "prop-types-extra": "^1.1.0",
         "react-overlays": "^5.0.0",
         "react-transition-group": "^4.4.1",
-        "uncontrollable": "^7.0.0",
+        "uncontrollable": "^7.2.1",
         "warning": "^4.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "react-clientside-effect": {
@@ -20729,9 +20990,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -21126,9 +21387,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.13.9",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.9.tgz",
-          "integrity": "sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==",
+          "version": "7.13.10",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+          "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -24587,11 +24848,11 @@
       "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg=="
     },
     "use-sidecar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.4.tgz",
-      "integrity": "sha512-A5ggIS3/qTdxCAlcy05anO2/oqXOfpmxnpRE1Jm+fHHtCvUvNSZDGqgOSAXPriBVAcw2fMFFkh5v5KqrFFhCMA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.5.tgz",
+      "integrity": "sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==",
       "requires": {
-        "detect-node-es": "^1.0.0",
+        "detect-node-es": "^1.1.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.0.11",
     "@edx/frontend-platform": "1.9.0",
-    "@edx/paragon": "13.13.5",
+    "@edx/paragon": "13.17.3",
     "@fortawesome/fontawesome-svg-core": "1.2.28",
     "@fortawesome/free-brands-svg-icons": "5.11.2",
     "@fortawesome/free-regular-svg-icons": "5.11.2",
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@edx/frontend-build": "5.6.9",
+    "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "10.4.7",
     "axios-mock-adapter": "1.18.1",
     "codecov": "3.7.1",

--- a/src/generic/FormSwitchGroup.jsx
+++ b/src/generic/FormSwitchGroup.jsx
@@ -6,12 +6,27 @@ export default function FormSwitchGroup({
   id, label, helpText, className, onChange, onBlur, checked,
 }) {
   const helpTextId = `${id}HelpText`;
+
+  // Note that we use controlId here _and_ set some IDs and aria-describedby attributes manually.
+  // controlId doesn't cover Form.Switch properly, so controlId is just helping to attach
+  // a 'for' attribute to the Label.
   return (
-    <Form.Group className={className}>
+    <Form.Group
+      controlId={id}
+      className={className}
+    >
       <div className="d-flex justify-content-between">
-        <Form.Label>
-          {label}
-        </Form.Label>
+        <div className="pr-3">
+          <Form.Label>
+            {label}
+          </Form.Label>
+          <Form.Text
+            id={helpTextId}
+            muted
+          >
+            {helpText}
+          </Form.Text>
+        </div>
         <Form.Switch
           id={id}
           aria-describedby={helpTextId}
@@ -20,9 +35,7 @@ export default function FormSwitchGroup({
           checked={checked}
         />
       </div>
-      <Form.Text id={helpTextId} muted>
-        {helpText}
-      </Form.Text>
+
     </Form.Group>
   );
 }

--- a/src/pages-and-resources/discussions/ConfigFormContainer.jsx
+++ b/src/pages-and-resources/discussions/ConfigFormContainer.jsx
@@ -21,10 +21,10 @@ function ConfigFormContainer({
     dispatch(fetchAppConfig(courseId, routeAppId));
   }, [courseId]);
 
-  const { activeAppId, activeAppConfigId } = useSelector(state => state.discussions);
+  const { displayedAppId, displayedAppConfigId } = useSelector(state => state.discussions);
 
-  const app = useModel('apps', activeAppId);
-  const appConfig = useModel('appConfigs', activeAppConfigId);
+  const app = useModel('apps', displayedAppId);
+  const appConfig = useModel('appConfigs', displayedAppConfigId);
 
   if (!appConfig || !app) {
     return null;
@@ -51,7 +51,7 @@ function ConfigFormContainer({
     );
   }
   return (
-    <Container size="xs" className="px-sm-0">
+    <Container size="sm" className="px-sm-0">
       <h3 className="my-4">
         {intl.formatMessage(messages.configureApp, { name: app.name })}
       </h3>

--- a/src/pages-and-resources/discussions/apps/legacy/LegacyConfigForm.jsx
+++ b/src/pages-and-resources/discussions/apps/legacy/LegacyConfigForm.jsx
@@ -1,30 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Form, TransitionReplace } from '@edx/paragon';
+import { Form } from '@edx/paragon';
 import { useFormik } from 'formik';
-import * as Yup from 'yup';
 
-import FormSwitchGroup from '../../../../generic/FormSwitchGroup';
-import messages from './messages';
+import DivisionByGroupFields from '../shared/DivisionByGroupFields';
+import AnonymousPostingFields from '../shared/AnonymousPostingFields';
+import BlackoutDatesField from '../shared/BlackoutDatesField';
 
-function LegacyConfigForm({
-  appConfig, onSubmit, intl, formRef,
+export default function LegacyConfigForm({
+  appConfig, onSubmit, formRef,
 }) {
-  // TODO: This regex doesn't seem to be working yet/validation isn't displaying.  Unclear why.
-  const blackoutDateRegex = /(\[\]|\[(\["\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}){0,1}"\])*\])/;
   const {
     handleSubmit,
     handleChange,
     handleBlur,
     values,
-    errors,
   } = useFormik({
     initialValues: appConfig,
-    validationSchema: Yup.object().shape({
-      blackoutDates: Yup.string().matches(blackoutDateRegex, 'bad regex'),
-
-    }),
     onSubmit,
   });
 
@@ -32,135 +24,23 @@ function LegacyConfigForm({
 
   return (
     <Form ref={formRef} onSubmit={handleSubmit}>
-      <h5>{intl.formatMessage(messages.divisionByGroup)}</h5>
-
-      <FormSwitchGroup
-        onChange={handleChange}
+      <h3>Legacy Discussions</h3>
+      <DivisionByGroupFields
         onBlur={handleBlur}
-        id="divideByCohorts"
-        checked={values.divideByCohorts}
-        label={intl.formatMessage(messages.divideByCohortsLabel)}
-        helpText={intl.formatMessage(messages.divideByCohortsHelp)}
+        onChange={handleChange}
+        values={values}
       />
-      <TransitionReplace>
-        {values.divideByCohorts ? (
-          <React.Fragment key="open">
-            <FormSwitchGroup
-              onChange={handleChange}
-              onBlur={handleBlur}
-              className="pl-4"
-              id="allowDivisionByUnit"
-              checked={values.allowDivisionByUnit}
-              label={intl.formatMessage(messages.allowDivisionByUnitLabel)}
-              helpText={intl.formatMessage(messages.allowDivisionByUnitHelp)}
-            />
-            <FormSwitchGroup
-              onChange={handleChange}
-              onBlur={handleBlur}
-              id="divideCourseWideTopics"
-              checked={values.divideCourseWideTopics}
-              label={intl.formatMessage(messages.divideCourseWideTopicsLabel)}
-              helpText={intl.formatMessage(messages.divideCourseWideTopicsHelp)}
-            />
-            <Form.Group>
-              <Form.Check
-                onChange={handleChange}
-                onBlur={handleBlur}
-                checked={values.divideGeneralTopic}
-                label="General"
-              />
-              <Form.Check
-                onChange={handleChange}
-                onBlur={handleBlur}
-                checked={values.divideQuestionsForTAs}
-                label="Questions for the TAs"
-              />
-            </Form.Group>
-          </React.Fragment>
-        ) : <React.Fragment key="closed" />}
-      </TransitionReplace>
-
       {divider}
-
-      <h5>{intl.formatMessage(messages.visibilityInContext)}</h5>
-      <FormSwitchGroup
-        onChange={handleChange}
+      <AnonymousPostingFields
         onBlur={handleBlur}
-        id="inContextDiscussion"
-        checked={values.inContextDiscussion}
-        label={intl.formatMessage(messages.inContextDiscussionLabel)}
-        helpText={intl.formatMessage(messages.inContextDiscussionHelp)}
-      />
-      <TransitionReplace>
-        {values.inContextDiscussion ? (
-          <React.Fragment key="open">
-            <FormSwitchGroup
-              onChange={handleChange}
-              onBlur={handleBlur}
-              className="pl-4"
-              id="gradedUnitPages"
-              checked={values.gradedUnitPages}
-              label={intl.formatMessage(messages.gradedUnitPagesLabel)}
-              helpText={intl.formatMessage(messages.gradedUnitPagesHelp)}
-            />
-            <FormSwitchGroup
-              onChange={handleChange}
-              onBlur={handleBlur}
-              className="pl-4"
-              id="groupInContextSubsection"
-              checked={values.groupInContextSubsection}
-              label={intl.formatMessage(messages.groupInContextSubsectionLabel)}
-              helpText={intl.formatMessage(messages.groupInContextSubsectionHelp)}
-            />
-            <FormSwitchGroup
-              onChange={handleChange}
-              onBlur={handleBlur}
-              className="pl-4"
-              id="allowUnitLevelVisibility"
-              checked={values.allowUnitLevelVisibility}
-              label={intl.formatMessage(messages.allowUnitLevelVisibilityLabel)}
-              helpText={intl.formatMessage(messages.allowUnitLevelVisibilityHelp)}
-            />
-          </React.Fragment>
-        ) : <React.Fragment key="closed" />}
-
-      </TransitionReplace>
-
-      {divider}
-      <h5>{intl.formatMessage(messages.anonymousPosting)}</h5>
-      <FormSwitchGroup
         onChange={handleChange}
-        onBlur={handleBlur}
-        id="allowAnonymousPosts"
-        checked={values.allowAnonymousPosts}
-        label={intl.formatMessage(messages.allowAnonymousPostsLabel)}
-        helpText={intl.formatMessage(messages.allowAnonymousPostsHelp)}
+        values={values}
       />
-      <FormSwitchGroup
+      <BlackoutDatesField
+        onBlur={handleBlur}
         onChange={handleChange}
-        onBlur={handleBlur}
-        id="allowAnonymousPostsPeers"
-        checked={values.allowAnonymousPostsPeers}
-        label={intl.formatMessage(messages.allowAnonymousPostsPeersLabel)}
-        helpText={intl.formatMessage(messages.allowAnonymousPostsPeersHelp)}
+        values={values}
       />
-      <Form.Group>
-        <Form.Label>{intl.formatMessage(messages.blackoutDatesLabel)}</Form.Label>
-        <Form.Control
-          id="blackoutDates"
-          aria-describedby="blackoutDatesHelpText"
-          value={values.blackoutDates}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          className={{ 'is-invalid': !!errors.launchUrl }}
-        />
-        <Form.Control.Feedback id="blackoutDatesFeedback" type="invalid">
-          Bad blackout date
-        </Form.Control.Feedback>
-        <Form.Text id="blackoutDatesHelpText" muted>
-          {intl.formatMessage(messages.blackoutDatesHelp)}
-        </Form.Text>
-      </Form.Group>
     </Form>
   );
 }
@@ -172,18 +52,11 @@ LegacyConfigForm.propTypes = {
     divideCourseWideTopics: PropTypes.bool.isRequired,
     divideGeneralTopic: PropTypes.bool.isRequired,
     divideQuestionsForTAs: PropTypes.bool.isRequired,
-    inContextDiscussion: PropTypes.bool.isRequired,
-    gradedUnitPages: PropTypes.bool.isRequired,
-    groupInContextSubsection: PropTypes.bool.isRequired,
-    allowUnitLevelVisibility: PropTypes.bool.isRequired,
     allowAnonymousPosts: PropTypes.bool.isRequired,
     allowAnonymousPostsPeers: PropTypes.bool.isRequired,
     blackoutDates: PropTypes.string.isRequired,
   }).isRequired,
-  intl: intlShape.isRequired,
   onSubmit: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   formRef: PropTypes.object.isRequired,
 };
-
-export default injectIntl(LegacyConfigForm);

--- a/src/pages-and-resources/discussions/apps/legacy/LegacyConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/apps/legacy/LegacyConfigForm.test.jsx
@@ -1,0 +1,109 @@
+import React, { createRef } from 'react';
+import { act, render } from '@testing-library/react';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import LegacyConfigForm from './LegacyConfigForm';
+
+const defaultAppConfig = {
+  id: 'legacy',
+  divideByCohorts: false,
+  allowDivisionByUnit: false,
+  divideCourseWideTopics: false,
+  divideGeneralTopic: false,
+  divideQuestionsForTAs: false,
+  allowAnonymousPosts: false,
+  allowAnonymousPostsPeers: false,
+  blackoutDates: '[]',
+};
+
+describe('LegacyConfigForm', () => {
+  test('calls onSubmit when the formRef is submitted', async () => {
+    const formRef = createRef();
+    const handleSubmit = jest.fn();
+
+    render(
+      <IntlProvider locale="en">
+        <LegacyConfigForm
+          appConfig={defaultAppConfig}
+          onSubmit={handleSubmit}
+          formRef={formRef}
+        />
+      </IntlProvider>,
+    );
+
+    await act(async () => {
+      formRef.current.submit();
+    });
+    expect(handleSubmit).toHaveBeenCalledWith(
+      // Because we use defaultAppConfig as the initialValues of the form, and we haven't changed
+      // any of the form inputs, this exact object shape is returned back to us, so we're reusing
+      // it here.  It's not supposed to be 'the same object', it just happens to be.
+      defaultAppConfig,
+      // The second argument is a Formik object with all sorts of functions on it which we don't
+      // care about.
+      expect.anything(),
+    );
+  });
+
+  test('default field states are correct, including removal of folded sub-fields', () => {
+    const { container } = render(
+      <IntlProvider locale="en">
+        <LegacyConfigForm
+          appConfig={defaultAppConfig}
+          onSubmit={jest.fn()}
+          formRef={createRef()}
+        />
+      </IntlProvider>,
+    );
+
+    // DivisionByGroupFields
+    expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
+    expect(container.querySelector('#divideByCohorts')).not.toBeChecked();
+    expect(container.querySelector('#allowDivisionByUnit')).not.toBeInTheDocument();
+    expect(container.querySelector('#divideCourseWideTopics')).not.toBeInTheDocument();
+    expect(container.querySelector('#divideGeneralTopic')).not.toBeInTheDocument();
+    expect(container.querySelector('#divideQuestionsForTAs')).not.toBeInTheDocument();
+
+    // AnonymousPostingFields
+    expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();
+    expect(container.querySelector('#allowAnonymousPosts')).not.toBeChecked();
+    expect(container.querySelector('#allowAnonymousPostsPeers')).not.toBeInTheDocument();
+
+    // BlackoutDatesField
+    expect(container.querySelector('#blackoutDates')).toBeInTheDocument();
+    expect(container.querySelector('#blackoutDates')).toHaveValue('[]');
+  });
+
+  test('folded sub-fields are in the DOM when parents are enabled', () => {
+    const { container } = render(
+      <IntlProvider locale="en">
+        <LegacyConfigForm
+          appConfig={{
+            ...defaultAppConfig,
+            divideByCohorts: true,
+            allowAnonymousPosts: true,
+          }}
+          onSubmit={jest.fn()}
+          formRef={createRef()}
+        />
+      </IntlProvider>,
+    );
+
+    // DivisionByGroupFields
+    expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
+    expect(container.querySelector('#divideByCohorts')).toBeChecked();
+    expect(container.querySelector('#allowDivisionByUnit')).toBeInTheDocument();
+    expect(container.querySelector('#allowDivisionByUnit')).not.toBeChecked();
+    expect(container.querySelector('#divideCourseWideTopics')).toBeInTheDocument();
+    expect(container.querySelector('#divideCourseWideTopics')).not.toBeChecked();
+    expect(container.querySelector('#divideGeneralTopic')).toBeInTheDocument();
+    expect(container.querySelector('#divideGeneralTopic')).not.toBeChecked();
+    expect(container.querySelector('#divideQuestionsForTAs')).toBeInTheDocument();
+    expect(container.querySelector('#divideQuestionsForTAs')).not.toBeChecked();
+
+    // AnonymousPostingFields
+    expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();
+    expect(container.querySelector('#allowAnonymousPosts')).toBeChecked();
+    expect(container.querySelector('#allowAnonymousPostsPeers')).toBeInTheDocument();
+    expect(container.querySelector('#allowAnonymousPostsPeers')).not.toBeChecked();
+  });
+});

--- a/src/pages-and-resources/discussions/apps/shared/AnonymousPostingFields.jsx
+++ b/src/pages-and-resources/discussions/apps/shared/AnonymousPostingFields.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { TransitionReplace } from '@edx/paragon';
+import FormSwitchGroup from '../../../../generic/FormSwitchGroup';
+import messages from './messages';
+
+function AnonymousPostingFields({
+  onBlur,
+  onChange,
+  intl,
+  values,
+}) {
+  return (
+    <>
+      <h5>{intl.formatMessage(messages.anonymousPosting)}</h5>
+      <FormSwitchGroup
+        onChange={onChange}
+        onBlur={onBlur}
+        id="allowAnonymousPosts"
+        checked={values.allowAnonymousPosts}
+        label={intl.formatMessage(messages.allowAnonymousPostsLabel)}
+        helpText={intl.formatMessage(messages.allowAnonymousPostsHelp)}
+      />
+      <TransitionReplace>
+        {values.allowAnonymousPosts ? (
+          <React.Fragment key="open">
+            <FormSwitchGroup
+              onChange={onChange}
+              onBlur={onBlur}
+              className="ml-4"
+              id="allowAnonymousPostsPeers"
+              checked={values.allowAnonymousPostsPeers}
+              label={intl.formatMessage(messages.allowAnonymousPostsPeersLabel)}
+              helpText={intl.formatMessage(messages.allowAnonymousPostsPeersHelp)}
+            />
+          </React.Fragment>
+        ) : <React.Fragment key="closed" />}
+      </TransitionReplace>
+    </>
+  );
+}
+
+AnonymousPostingFields.propTypes = {
+  onBlur: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
+  values: PropTypes.shape({
+    allowAnonymousPosts: PropTypes.bool,
+    allowAnonymousPostsPeers: PropTypes.bool,
+  }).isRequired,
+};
+
+export default injectIntl(AnonymousPostingFields);

--- a/src/pages-and-resources/discussions/apps/shared/BlackoutDatesField.jsx
+++ b/src/pages-and-resources/discussions/apps/shared/BlackoutDatesField.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Form } from '@edx/paragon';
+import messages from './messages';
+
+function BlackoutDatesField({
+  onBlur,
+  onChange,
+  intl,
+  values,
+}) {
+  return (
+    <>
+      <h5 className="mb-3">{intl.formatMessage(messages.blackoutDates)}</h5>
+      <Form.Group
+        controlId="blackoutDates"
+      >
+        <Form.Control
+          value={values.blackoutDates}
+          onChange={onChange}
+          onBlur={onBlur}
+          floatingLabel={intl.formatMessage(messages.blackoutDatesLabel)}
+        />
+        <Form.Text muted>
+          {intl.formatMessage(messages.blackoutDatesHelp)}
+        </Form.Text>
+      </Form.Group>
+    </>
+  );
+}
+
+BlackoutDatesField.propTypes = {
+  onBlur: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
+  values: PropTypes.shape({
+    blackoutDates: PropTypes.string,
+  }).isRequired,
+};
+
+export default injectIntl(BlackoutDatesField);

--- a/src/pages-and-resources/discussions/apps/shared/DivisionByGroupFields.jsx
+++ b/src/pages-and-resources/discussions/apps/shared/DivisionByGroupFields.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Form, TransitionReplace } from '@edx/paragon';
+import FormSwitchGroup from '../../../../generic/FormSwitchGroup';
+import messages from './messages';
+
+function DivisionByGroupFields({
+  onBlur,
+  onChange,
+  intl,
+  values,
+}) {
+  return (
+    <>
+      <h5>{intl.formatMessage(messages.divisionByGroup)}</h5>
+
+      <FormSwitchGroup
+        onChange={onChange}
+        onBlur={onBlur}
+        id="divideByCohorts"
+        checked={values.divideByCohorts}
+        label={intl.formatMessage(messages.divideByCohortsLabel)}
+        helpText={intl.formatMessage(messages.divideByCohortsHelp)}
+      />
+      <TransitionReplace>
+        {values.divideByCohorts ? (
+          <React.Fragment key="open">
+            <FormSwitchGroup
+              onChange={onChange}
+              onBlur={onBlur}
+              className="ml-4"
+              id="allowDivisionByUnit"
+              checked={values.allowDivisionByUnit}
+              label={intl.formatMessage(messages.allowDivisionByUnitLabel)}
+              helpText={intl.formatMessage(messages.allowDivisionByUnitHelp)}
+            />
+            <FormSwitchGroup
+              onChange={onChange}
+              onBlur={onBlur}
+              className="ml-4"
+              id="divideCourseWideTopics"
+              checked={values.divideCourseWideTopics}
+              label={intl.formatMessage(messages.divideCourseWideTopicsLabel)}
+              helpText={intl.formatMessage(messages.divideCourseWideTopicsHelp)}
+            />
+            <Form.Group className="ml-4">
+              <Form.Check
+                id="divideGeneralTopic"
+                onChange={onChange}
+                onBlur={onBlur}
+                checked={values.divideGeneralTopic}
+                label="General"
+              />
+              <Form.Check
+                id="divideQuestionsForTAs"
+                onChange={onChange}
+                onBlur={onBlur}
+                checked={values.divideQuestionsForTAs}
+                label="Questions for the TAs"
+              />
+            </Form.Group>
+          </React.Fragment>
+        ) : <React.Fragment key="closed" />}
+      </TransitionReplace>
+    </>
+  );
+}
+
+DivisionByGroupFields.propTypes = {
+  onBlur: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
+  values: PropTypes.shape({
+    divideByCohorts: PropTypes.bool,
+    allowDivisionByUnit: PropTypes.bool,
+    divideCourseWideTopics: PropTypes.bool,
+    divideGeneralTopic: PropTypes.bool,
+    divideQuestionsForTAs: PropTypes.bool,
+  }).isRequired,
+};
+
+export default injectIntl(DivisionByGroupFields);

--- a/src/pages-and-resources/discussions/apps/shared/InContextDiscussionFields.jsx
+++ b/src/pages-and-resources/discussions/apps/shared/InContextDiscussionFields.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { TransitionReplace } from '@edx/paragon';
+import FormSwitchGroup from '../../../../generic/FormSwitchGroup';
+import messages from './messages';
+
+function InContextDiscussionFields({
+  onBlur,
+  onChange,
+  intl,
+  values,
+}) {
+  return (
+    <>
+      <h5>{intl.formatMessage(messages.visibilityInContext)}</h5>
+      <FormSwitchGroup
+        onChange={onChange}
+        onBlur={onBlur}
+        id="inContextDiscussion"
+        checked={values.inContextDiscussion}
+        label={intl.formatMessage(messages.inContextDiscussionLabel)}
+        helpText={intl.formatMessage(messages.inContextDiscussionHelp)}
+      />
+      <TransitionReplace>
+        {values.inContextDiscussion ? (
+          <React.Fragment key="open">
+            <FormSwitchGroup
+              onChange={onChange}
+              onBlur={onBlur}
+              className="ml-4"
+              id="gradedUnitPages"
+              checked={values.gradedUnitPages}
+              label={intl.formatMessage(messages.gradedUnitPagesLabel)}
+              helpText={intl.formatMessage(messages.gradedUnitPagesHelp)}
+            />
+            <FormSwitchGroup
+              onChange={onChange}
+              onBlur={onBlur}
+              className="ml-4"
+              id="groupInContextSubsection"
+              checked={values.groupInContextSubsection}
+              label={intl.formatMessage(messages.groupInContextSubsectionLabel)}
+              helpText={intl.formatMessage(messages.groupInContextSubsectionHelp)}
+            />
+            <FormSwitchGroup
+              onChange={onChange}
+              onBlur={onBlur}
+              className="ml-4"
+              id="allowUnitLevelVisibility"
+              checked={values.allowUnitLevelVisibility}
+              label={intl.formatMessage(messages.allowUnitLevelVisibilityLabel)}
+              helpText={intl.formatMessage(messages.allowUnitLevelVisibilityHelp)}
+            />
+          </React.Fragment>
+        ) : <React.Fragment key="closed" />}
+
+      </TransitionReplace>
+    </>
+  );
+}
+
+InContextDiscussionFields.propTypes = {
+  onBlur: PropTypes.func.isRequired,
+  onChange: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
+  values: PropTypes.shape({
+    inContextDiscussion: PropTypes.bool,
+    gradedUnitPages: PropTypes.bool,
+    groupInContextSubsection: PropTypes.bool,
+    allowUnitLevelVisibility: PropTypes.bool,
+  }).isRequired,
+};
+
+export default injectIntl(InContextDiscussionFields);

--- a/src/pages-and-resources/discussions/apps/shared/messages.js
+++ b/src/pages-and-resources/discussions/apps/shared/messages.js
@@ -1,6 +1,7 @@
 import { defineMessages } from '@edx/frontend-platform/i18n';
 
 const messages = defineMessages({
+  // Division fields
   divisionByGroup: {
     id: 'authoring.discussions.builtIn.divisionByGroup',
     defaultMessage: 'Division by group',
@@ -29,6 +30,8 @@ const messages = defineMessages({
     id: 'authoring.discussions.builtIn.divideCourseWideTopics.help',
     defaultMessage: 'Choose which of your general course wide discussion topics you would like to divide.',
   },
+
+  // In-context discussion fields
   visibilityInContext: {
     id: 'authoring.discussions.builtIn.visibilityInContext',
     defaultMessage: 'Visibility of in-context discussions',
@@ -65,6 +68,8 @@ const messages = defineMessages({
     id: 'authoring.discussions.builtIn.allowUnitLevelVisibility.help',
     defaultMessage: 'With this advanced setting enabled you will be able to override the global visibility setting and turn discussions on or off for each unit from the course outline view..',
   },
+
+  // Anonymous posting fields
   anonymousPosting: {
     id: 'authoring.discussions.builtIn.anonymousPosting',
     defaultMessage: 'Anonymous posting',
@@ -85,9 +90,16 @@ const messages = defineMessages({
     id: 'authoring.discussions.builtIn.allowAnonymousPeers.help',
     defaultMessage: 'Enter true or false. If true, students can create discussion posts that are anonymous to other students. This setting does not make posts anonymous to course staff.',
   },
+
+  // Blackout dates
+  blackoutDates: {
+    id: 'authoring.discussions.blackoutDates',
+    defaultMessage: 'Discussion blackout dates',
+
+  },
   blackoutDatesLabel: {
     id: 'authoring.discussions.builtIn.blackoutDates.label',
-    defaultMessage: 'Discussion Blackout Dates',
+    defaultMessage: 'Blackout dates',
   },
   blackoutDatesHelp: {
     id: 'authoring.discussions.builtIn.blackoutDates.help',

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -27,30 +27,18 @@ export async function getApps(courseId) {
 }
 
 const legacyEdXDiscussions = {
-  id: 'edx-discussions',
-  name: 'edX Discussions',
-  logo: 'https://cdn-blog.lawrencemcdaniel.com/wp-content/uploads/2018/01/22125436/edx-logo.png',
-  description: 'Start conversations with other learners, ask questions, and interact with other learners in the course.',
-  supportLevel: 'Full support',
-  isAvailable: true,
-  documentationUrl: 'https://localhost/docs',
+  id: 'legacy',
+  hasFullSupport: false,
   featureIds: [
-    'lti',
     'discussion-page',
     'embedded-course-sections',
-    'embedded-course-units',
     'wcag-2.1',
   ],
 };
 
 const piazzaApp = {
   id: 'piazza',
-  name: 'Piazza',
-  logo: 'https://piazza.com/images/splash2/topbar/piazza_logo_blue.png',
-  description: 'Piazza is designed to connect students, TAs, and professors so every student can get the help they need when they need it.',
-  supportLevel: 'Partial support',
-  isAvailable: true,
-  documentationUrl: 'https://localhost/docs',
+  hasFullSupport: false,
   featureIds: [
     'lti',
     'discussion-page',
@@ -61,12 +49,7 @@ const piazzaApp = {
 
 const yellowdigApp = {
   id: 'yellowdig',
-  name: 'Yellowdig',
-  logo: 'https://static.wixstatic.com/media/e53d7e_f8a17bd41db64a57a8d62bea4fdf3174~mv2.png/v1/crop/x_5,y_0,w_895,h_196/fill/w_366,h_80,al_c,q_85,usm_0.66_1.00_0.01/yellowdig-logo.webp',
-  description: 'Yellowdig is the digital solution that impacts the entire student lifecycle and enables lifelong learning.',
-  supportLevel: 'Coming soon',
-  isAvailable: false,
-  documentationUrl: 'https://localhost/docs',
+  hasFullSupport: false,
   featureIds: [
     'lti',
     'discussion-page',
@@ -95,9 +78,9 @@ export function getAppConfig(courseId, appId) {
     launchUrl: 'https://localhost/launch',
   };
 
-  if (appId === 'edx-discussions') {
+  if (appId === 'legacy') {
     appConfig = {
-      id: 'appConfig2',
+      id: 'legacy',
       divideByCohorts: false,
       allowDivisionByUnit: false,
       divideCourseWideTopics: false,

--- a/src/pages-and-resources/discussions/data/slice.js
+++ b/src/pages-and-resources/discussions/data/slice.js
@@ -12,20 +12,24 @@ const slice = createSlice({
   name: 'discussions',
   initialState: {
     appIds: [],
+    // "active" IDs are for the app and config that has been enabled for the course.
     activeAppId: null,
-    activeAppConfigId: null,
+    // "displayed" IDs are for the app and config that are being configured in the UI.  They may be
+    // the same as the "active" IDs.
+    displayedAppId: null,
+    displayedAppConfigId: null,
     featureIds: [],
     status: LOADING,
   },
   reducers: {
     fetchAppsSuccess: (state, { payload }) => {
+      state.activeAppId = payload.activeAppId;
       state.appIds = payload.appIds;
       state.featureIds = payload.featureIds;
-      state.activeAppId = payload.activeAppId;
     },
     fetchAppConfigSuccess: (state, { payload }) => {
-      state.activeAppId = payload.activeAppId;
-      state.activeAppConfigId = payload.activeAppConfigId;
+      state.displayedAppConfigId = payload.displayedAppConfigId;
+      state.displayedAppId = payload.displayedAppId;
       state.featureIds = payload.featureIds;
     },
     updateStatus: (state, { payload }) => {

--- a/src/pages-and-resources/discussions/data/thunks.js
+++ b/src/pages-and-resources/discussions/data/thunks.js
@@ -50,9 +50,10 @@ export function fetchAppConfig(courseId, appId) {
       dispatch(addModel({ modelType: 'apps', model: app }));
       dispatch(addModels({ modelType: 'features', models: features }));
       dispatch(addModel({ modelType: 'appConfigs', model: appConfig }));
+
       dispatch(fetchAppConfigSuccess({
-        activeAppId: app.id,
-        activeAppConfigId: appConfig.id,
+        displayedAppId: app.id,
+        displayedAppConfigId: appConfig.id,
         featureIds: features.map(feature => feature.id),
       }));
       dispatch(updateStatus({ courseId, status: LOADED }));

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,5 +1,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import { configure } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
 
 configure({ testIdAttribute: 'data-test-id' });


### PR DESCRIPTION
This PR is best reviewed commit-by-commit.

It refactors LegacyConfigForm in preparation for creation of "StandardConfigForm", which will be for configuring our new discussions MFE.  It also adds tests for LegacyConfigForm and fixes some issues in the data layer about how we were treating "displayed" vs. "active" app configs.  See relevant commits for more information.  