### PR TITLE
Updated heading text

### DIFF
--- a/src/pages-and-resources/discussions/messages.js
+++ b/src/pages-and-resources/discussions/messages.js
@@ -3,7 +3,7 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 const messages = defineMessages({
   heading: {
     id: 'authoring.discussions.heading',
-    defaultMessage: 'Select a discussion tool for this course',
+    defaultMessage: 'Which discussion tool would you like to use for this course?',
   },
   supportedFeatures: {
     id: 'authoring.discussions.supportedFeatures',


### PR DESCRIPTION
[TNL-8108](https://openedx.atlassian.net/browse/TNL-8108)

Updated the heading text to match the Miro board

Before:
<img width="1359" alt="Screenshot 2021-04-07 at 6 10 46 PM" src="https://user-images.githubusercontent.com/10988308/113872294-33517b80-97cd-11eb-8044-0965f78c6ee9.png">


After:
<img width="1339" alt="Screenshot 2021-04-07 at 6 09 45 PM" src="https://user-images.githubusercontent.com/10988308/113872367-3fd5d400-97cd-11eb-8b63-3a207e332a77.png">

