### PR TITLE
fix: default discussions provider to legacy

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.jsx
@@ -52,7 +52,7 @@ function DiscussionsSettings({ courseId, intl }) {
     } else {
       history.push(discussionsPath);
     }
-  }, [discussionsPath]);
+  }, [discussionsPath, isFirstStep, pagesAndResourcesPath]);
 
   return (
     <DiscussionsProvider path={discussionsPath}>

--- a/src/pages-and-resources/discussions/app-list/data/api.js
+++ b/src/pages-and-resources/discussions/app-list/data/api.js
@@ -14,7 +14,13 @@ function normalizeApps(data) {
       id,
     })),
     appConfig: data.plugin_configuration,
-    activeAppId: data.providers.active,
+    // TODO: Defaulting to "legacy" should come from the backend.  For now this makes sense as we
+    // don't create a DiscussionsConfiguration object in the backend for legacy discussions, which
+    // is configured by default on all courses.  The endpoint doesn't know this and returns a null
+    // for `active`, which we can then interpret as "the user hasn't configured something else" and
+    // choose to fall back to legacy.  In the long run, we should be able to trust `active` to give
+    // us 'legacy' if the legacy experience is being used.
+    activeAppId: data.providers.active || 'legacy',
     apps,
   };
 }

--- a/src/pages-and-resources/discussions/app-list/data/slice.js
+++ b/src/pages-and-resources/discussions/app-list/data/slice.js
@@ -21,11 +21,15 @@ const slice = createSlice({
   reducers: {
     loadApps: (state, { payload }) => {
       state.activeAppId = payload.activeAppId;
+      // When the UI loads, we want to set the selectedAppId to the activeAppId.  This ensures the
+      // active one will be checked.
+      state.selectedAppId = payload.activeAppId;
       state.appIds = payload.appIds;
       state.featureIds = payload.featureIds;
       state.status = LOADED;
     },
-    selectApp: (state, { appId }) => {
+    selectApp: (state, { payload }) => {
+      const { appId } = payload;
       state.selectedAppId = appId;
     },
     updateStatus: (state, { status }) => {


### PR DESCRIPTION
This defaults our discussions provider to legacy if one was not specified by the backend.

It also fixes a few navigation and provider selection bugs that I encountered in testing the above.

Fixes: 

- https://openedx.atlassian.net/browse/TNL-8114
- https://openedx.atlassian.net/browse/TNL-8120