### PR TITLE
Update step names, form titles, and add dividers

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.jsx
@@ -31,7 +31,7 @@ function DiscussionsSettings({ courseId, intl }) {
   const isFirstStep = pathname === discussionsPath;
 
   const steps = [{
-    label: intl.formatMessage(messages.selectDiscussionTool),
+    label: intl.formatMessage(messages.providerSelection),
     iconLabel: isFirstStep ? undefined : (
       <Check style={{ width: '1rem', height: '1rem' }} />
     ),

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
@@ -4,7 +4,7 @@ import React, {
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useRouteMatch } from 'react-router';
-import { Card, Container } from '@edx/paragon';
+import { Container } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { history } from '@edx/frontend-platform';
 import { useModel } from '../../../generic/model-store';
@@ -52,6 +52,7 @@ function AppConfigForm({
         formRef={formRef}
         appConfig={appConfig}
         onSubmit={handleSubmit}
+        title={intl.formatMessage(messages[`appName-${app.id}`])}
       />
     );
   } else {
@@ -61,17 +62,13 @@ function AppConfigForm({
         app={app}
         appConfig={appConfig}
         onSubmit={handleSubmit}
+        title={intl.formatMessage(messages[`appName-${app.id}`])}
       />
     );
   }
   return (
-    <Container size="sm" className="px-sm-0">
-      <h3 className="my-4">
-        {intl.formatMessage(messages.configureApp, { name: app.name })}
-      </h3>
-      <Card className="mb-5 p-5">
-        {form}
-      </Card>
+    <Container size="sm" className="px-sm-0 py-5">
+      {form}
     </Container>
   );
 }

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form } from '@edx/paragon';
+import { Card, Form } from '@edx/paragon';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -13,7 +13,7 @@ import messages from '../shared/messages';
 import AppConfigFormDivider from '../shared/AppConfigFormDivider';
 
 function LegacyConfigForm({
-  appConfig, onSubmit, formRef, intl,
+  appConfig, onSubmit, formRef, intl, title,
 }) {
   const {
     handleSubmit,
@@ -33,26 +33,28 @@ function LegacyConfigForm({
   });
 
   return (
-    <Form ref={formRef} onSubmit={handleSubmit}>
-      <h3>Legacy Discussions</h3>
+    <Card className="mb-5 pt-3 px-5 pb-5">
+      <Form ref={formRef} onSubmit={handleSubmit}>
+        <h3>{title}</h3>
         <AppConfigFormDivider />
-      <DivisionByGroupFields
-        onBlur={handleBlur}
-        onChange={handleChange}
-        values={values}
-      />
-      <AnonymousPostingFields
-        onBlur={handleBlur}
-        onChange={handleChange}
-        values={values}
-      />
-      <BlackoutDatesField
-        errors={errors}
-        onBlur={handleBlur}
-        onChange={handleChange}
-        values={values}
-      />
-    </Form>
+        <DivisionByGroupFields
+          onBlur={handleBlur}
+          onChange={handleChange}
+          values={values}
+        />
+        <AnonymousPostingFields
+          onBlur={handleBlur}
+          onChange={handleChange}
+          values={values}
+        />
+        <BlackoutDatesField
+          errors={errors}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          values={values}
+        />
+      </Form>
+    </Card>
   );
 }
 
@@ -71,6 +73,7 @@ LegacyConfigForm.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   formRef: PropTypes.object.isRequired,
   intl: intlShape.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default injectIntl(LegacyConfigForm);

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
@@ -10,6 +10,7 @@ import AnonymousPostingFields from '../shared/AnonymousPostingFields';
 import BlackoutDatesField, { blackoutDatesRegex } from '../shared/BlackoutDatesField';
 
 import messages from '../shared/messages';
+import AppConfigFormDivider from '../shared/AppConfigFormDivider';
 
 function LegacyConfigForm({
   appConfig, onSubmit, formRef, intl,
@@ -31,17 +32,15 @@ function LegacyConfigForm({
     onSubmit,
   });
 
-  const divider = <hr className="my-2" />;
-
   return (
     <Form ref={formRef} onSubmit={handleSubmit}>
       <h3>Legacy Discussions</h3>
+        <AppConfigFormDivider />
       <DivisionByGroupFields
         onBlur={handleBlur}
         onChange={handleChange}
         values={values}
       />
-      {divider}
       <AnonymousPostingFields
         onBlur={handleBlur}
         onChange={handleChange}

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
@@ -42,11 +42,13 @@ function LegacyConfigForm({
           onChange={handleChange}
           values={values}
         />
+        <AppConfigFormDivider thick />
         <AnonymousPostingFields
           onBlur={handleBlur}
           onChange={handleChange}
           values={values}
         />
+        <AppConfigFormDivider thick />
         <BlackoutDatesField
           errors={errors}
           onBlur={handleBlur}

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -6,6 +6,7 @@ import { useFormik } from 'formik';
 import * as Yup from 'yup';
 
 import messages from './messages';
+import AppConfigFormDivider from '../shared/AppConfigFormDivider';
 
 function LtiConfigForm({
   appConfig, app, onSubmit, intl, formRef,
@@ -28,6 +29,7 @@ function LtiConfigForm({
 
   return (
     <Form ref={formRef} onSubmit={handleSubmit}>
+        <AppConfigFormDivider />
       <p>
         <FormattedMessage
           id="authoring.discussions.appDocInstructions"

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/i18n';
-import { Form, Hyperlink } from '@edx/paragon';
+import { Card, Form, Hyperlink } from '@edx/paragon';
 import { useFormik } from 'formik';
 import * as Yup from 'yup';
 
@@ -9,7 +9,7 @@ import messages from './messages';
 import AppConfigFormDivider from '../shared/AppConfigFormDivider';
 
 function LtiConfigForm({
-  appConfig, app, onSubmit, intl, formRef,
+  appConfig, app, onSubmit, intl, formRef, title,
 }) {
   const {
     handleSubmit,
@@ -28,67 +28,70 @@ function LtiConfigForm({
   });
 
   return (
-    <Form ref={formRef} onSubmit={handleSubmit}>
+    <Card className="mb-5 pt-3 px-5 pb-5">
+      <Form ref={formRef} onSubmit={handleSubmit}>
+        <h3>{title}</h3>
         <AppConfigFormDivider />
-      <p>
-        <FormattedMessage
-          id="authoring.discussions.appDocInstructions"
-          defaultMessage="{documentationPageLink} to set up the tool, then paste your consumer key and consumer secret below:"
-          description="Instructions for the user to go visit a third party app's documentation to learn how to generate a set of values needed in this form.  documentationPageLink says 'Visit the {name} documentation page'"
-          values={{
-            documentationPageLink: (
-              <Hyperlink
-                destination={app.documentationUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {intl.formatMessage(messages.documentationPage, { name: app.name })}
-              </Hyperlink>
-            ),
-            name: app.name,
-          }}
-        />
-      </p>
-      <Form.Group controlId="consumerKey" isInvalid={errors.consumerKey}>
-        <Form.Label>{intl.formatMessage(messages.consumerKey)}</Form.Label>
-        <Form.Control
-          onChange={handleChange}
-          onBlur={handleBlur}
-          value={values.consumerKey}
-        />
-        {errors.consumerKey && (
+        <p>
+          <FormattedMessage
+            id="authoring.discussions.appDocInstructions"
+            defaultMessage="{documentationPageLink} to set up the tool, then paste your consumer key and consumer secret below:"
+            description="Instructions for the user to go visit a third party app's documentation to learn how to generate a set of values needed in this form.  documentationPageLink says 'Visit the {name} documentation page'"
+            values={{
+              documentationPageLink: (
+                <Hyperlink
+                  destination={app.documentationUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {intl.formatMessage(messages.documentationPage, { name: app.name })}
+                </Hyperlink>
+              ),
+              name: app.name,
+            }}
+          />
+        </p>
+        <Form.Group controlId="consumerKey" isInvalid={errors.consumerKey}>
+          <Form.Label>{intl.formatMessage(messages.consumerKey)}</Form.Label>
+          <Form.Control
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.consumerKey}
+          />
+          {errors.consumerKey && (
           <Form.Control.Feedback type="invalid">
             {errors.consumerKey}
           </Form.Control.Feedback>
-        )}
-      </Form.Group>
-      <Form.Group controlId="consumerSecret" isInvalid={errors.consumerSecret}>
-        <Form.Label>{intl.formatMessage(messages.consumerSecret)}</Form.Label>
-        <Form.Control
-          onChange={handleChange}
-          onBlur={handleBlur}
-          value={values.consumerSecret}
-        />
-        {errors.consumerSecret && (
+          )}
+        </Form.Group>
+        <Form.Group controlId="consumerSecret" isInvalid={errors.consumerSecret}>
+          <Form.Label>{intl.formatMessage(messages.consumerSecret)}</Form.Label>
+          <Form.Control
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.consumerSecret}
+          />
+          {errors.consumerSecret && (
           <Form.Control.Feedback type="invalid">
             {errors.consumerSecret}
           </Form.Control.Feedback>
-        )}
-      </Form.Group>
-      <Form.Group controlId="launchUrl" isInvalid={errors.launchUrl}>
-        <Form.Label>{intl.formatMessage(messages.launchUrl)}</Form.Label>
-        <Form.Control
-          onChange={handleChange}
-          onBlur={handleBlur}
-          value={values.launchUrl}
-        />
-        {errors.launchUrl && (
+          )}
+        </Form.Group>
+        <Form.Group controlId="launchUrl" isInvalid={errors.launchUrl}>
+          <Form.Label>{intl.formatMessage(messages.launchUrl)}</Form.Label>
+          <Form.Control
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.launchUrl}
+          />
+          {errors.launchUrl && (
           <Form.Control.Feedback type="invalid">
             {errors.launchUrl}
           </Form.Control.Feedback>
-        )}
-      </Form.Group>
-    </Form>
+          )}
+        </Form.Group>
+      </Form>
+    </Card>
   );
 }
 
@@ -107,6 +110,7 @@ LtiConfigForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   formRef: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default injectIntl(LtiConfigForm);

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx
@@ -23,10 +23,10 @@ function AnonymousPostingFields({
         label={intl.formatMessage(messages.allowAnonymousPostsLabel)}
         helpText={intl.formatMessage(messages.allowAnonymousPostsHelp)}
       />
-      <AppConfigFormDivider />
       <TransitionReplace>
         {values.allowAnonymousPosts ? (
           <React.Fragment key="open">
+            <AppConfigFormDivider />
             <FormSwitchGroup
               onChange={onChange}
               onBlur={onBlur}
@@ -36,7 +36,6 @@ function AnonymousPostingFields({
               label={intl.formatMessage(messages.allowAnonymousPostsPeersLabel)}
               helpText={intl.formatMessage(messages.allowAnonymousPostsPeersHelp)}
             />
-            <AppConfigFormDivider />
           </React.Fragment>
         ) : <React.Fragment key="closed" />}
       </TransitionReplace>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/AnonymousPostingFields.jsx
@@ -4,6 +4,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { TransitionReplace } from '@edx/paragon';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
 import messages from './messages';
+import AppConfigFormDivider from './AppConfigFormDivider';
 
 function AnonymousPostingFields({
   onBlur,
@@ -22,6 +23,7 @@ function AnonymousPostingFields({
         label={intl.formatMessage(messages.allowAnonymousPostsLabel)}
         helpText={intl.formatMessage(messages.allowAnonymousPostsHelp)}
       />
+      <AppConfigFormDivider />
       <TransitionReplace>
         {values.allowAnonymousPosts ? (
           <React.Fragment key="open">
@@ -34,6 +36,7 @@ function AnonymousPostingFields({
               label={intl.formatMessage(messages.allowAnonymousPostsPeersLabel)}
               helpText={intl.formatMessage(messages.allowAnonymousPostsPeersHelp)}
             />
+            <AppConfigFormDivider />
           </React.Fragment>
         ) : <React.Fragment key="closed" />}
       </TransitionReplace>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/AppConfigFormDivider.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/AppConfigFormDivider.jsx
@@ -1,13 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default function AppConfigFormDivider() {
+export default function AppConfigFormDivider({ thick }) {
   return (
     <hr
       className="my-2"
       style={{
+        borderTopWidth: thick ? '3px' : '1px',
         marginLeft: '-48px',
         marginRight: '-48px',
       }}
     />
   );
 }
+
+AppConfigFormDivider.propTypes = {
+  thick: PropTypes.bool,
+};
+
+AppConfigFormDivider.defaultProps = {
+  thick: false,
+};

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/AppConfigFormDivider.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/AppConfigFormDivider.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function AppConfigFormDivider() {
+  return (
+    <hr
+      className="my-2"
+      style={{
+        marginLeft: '-48px',
+        marginRight: '-48px',
+      }}
+    />
+  );
+}

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
@@ -4,6 +4,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Form, TransitionReplace } from '@edx/paragon';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
 import messages from './messages';
+import AppConfigFormDivider from './AppConfigFormDivider';
 
 function DivisionByGroupFields({
   onBlur,
@@ -23,6 +24,7 @@ function DivisionByGroupFields({
         label={intl.formatMessage(messages.divideByCohortsLabel)}
         helpText={intl.formatMessage(messages.divideByCohortsHelp)}
       />
+      <AppConfigFormDivider />
       <TransitionReplace>
         {values.divideByCohorts ? (
           <React.Fragment key="open">
@@ -35,6 +37,7 @@ function DivisionByGroupFields({
               label={intl.formatMessage(messages.allowDivisionByUnitLabel)}
               helpText={intl.formatMessage(messages.allowDivisionByUnitHelp)}
             />
+            <AppConfigFormDivider />
             <FormSwitchGroup
               onChange={onChange}
               onBlur={onBlur}
@@ -60,6 +63,7 @@ function DivisionByGroupFields({
                 label="Questions for the TAs"
               />
             </Form.Group>
+            <AppConfigFormDivider />
           </React.Fragment>
         ) : <React.Fragment key="closed" />}
       </TransitionReplace>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
@@ -24,10 +24,10 @@ function DivisionByGroupFields({
         label={intl.formatMessage(messages.divideByCohortsLabel)}
         helpText={intl.formatMessage(messages.divideByCohortsHelp)}
       />
-      <AppConfigFormDivider />
       <TransitionReplace>
         {values.divideByCohorts ? (
           <React.Fragment key="open">
+            <AppConfigFormDivider />
             <FormSwitchGroup
               onChange={onChange}
               onBlur={onBlur}
@@ -63,7 +63,6 @@ function DivisionByGroupFields({
                 label="Questions for the TAs"
               />
             </Form.Group>
-            <AppConfigFormDivider />
           </React.Fragment>
         ) : <React.Fragment key="closed" />}
       </TransitionReplace>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/InContextDiscussionFields.jsx
@@ -4,6 +4,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { TransitionReplace } from '@edx/paragon';
 import FormSwitchGroup from '../../../../../generic/FormSwitchGroup';
 import messages from './messages';
+import AppConfigFormDivider from './AppConfigFormDivider';
 
 function InContextDiscussionFields({
   onBlur,
@@ -22,6 +23,7 @@ function InContextDiscussionFields({
         label={intl.formatMessage(messages.inContextDiscussionLabel)}
         helpText={intl.formatMessage(messages.inContextDiscussionHelp)}
       />
+      <AppConfigFormDivider />
       <TransitionReplace>
         {values.inContextDiscussion ? (
           <React.Fragment key="open">
@@ -34,6 +36,7 @@ function InContextDiscussionFields({
               label={intl.formatMessage(messages.gradedUnitPagesLabel)}
               helpText={intl.formatMessage(messages.gradedUnitPagesHelp)}
             />
+            <AppConfigFormDivider />
             <FormSwitchGroup
               onChange={onChange}
               onBlur={onBlur}
@@ -43,6 +46,7 @@ function InContextDiscussionFields({
               label={intl.formatMessage(messages.groupInContextSubsectionLabel)}
               helpText={intl.formatMessage(messages.groupInContextSubsectionHelp)}
             />
+            <AppConfigFormDivider />
             <FormSwitchGroup
               onChange={onChange}
               onBlur={onBlur}
@@ -52,6 +56,7 @@ function InContextDiscussionFields({
               label={intl.formatMessage(messages.allowUnitLevelVisibilityLabel)}
               helpText={intl.formatMessage(messages.allowUnitLevelVisibilityHelp)}
             />
+            <AppConfigFormDivider />
           </React.Fragment>
         ) : <React.Fragment key="closed" />}
 

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -29,11 +29,6 @@ const messages = defineMessages({
     defaultMessage: 'Applied',
     description: 'Button label when the discussion configuration has been successfully submitted.',
   },
-  selectDiscussionTool: {
-    id: 'authoring.discussions.selectDiscussionTool',
-    defaultMessage: 'Select discussion tool',
-    description: 'A label for the first step of a wizard where the user chooses a discussion tool to configure.',
-  },
 });
 
 export default messages;

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -29,6 +29,18 @@ const messages = defineMessages({
     defaultMessage: 'Applied',
     description: 'Button label when the discussion configuration has been successfully submitted.',
   },
+
+  // App names
+  'appName-piazza': {
+    id: 'authoring.discussions.appConfigForm.appName-piazza',
+    defaultMessage: 'Piazza',
+    description: 'The name of the Piazza app.',
+  },
+  'appName-legacy': {
+    id: 'authoring.discussions.appConfigForm.appName-legacy',
+    defaultMessage: 'edX Discussions',
+    description: 'The name of the Legacy edX Discussions app.',
+  },
 });
 
 export default messages;

--- a/src/pages-and-resources/discussions/app-list/messages.js
+++ b/src/pages-and-resources/discussions/app-list/messages.js
@@ -32,23 +32,23 @@ const messages = defineMessages({
 
   // Legacy
   'appName-legacy': {
-    id: 'authoring.discussions.appName-legacy',
-    defaultMessage: 'Legacy edX Discussions',
+    id: 'authoring.discussions.appList.appName-legacy',
+    defaultMessage: 'edX Discussions',
     description: 'The name of the Legacy edX Discussions app.',
   },
   'appDescription-legacy': {
-    id: 'authoring.discussions.appDescription-legacy',
+    id: 'authoring.discussions.appList.appDescription-legacy',
     defaultMessage: 'Start conversations with other learners, ask questions, and interact with other learners in the course.',
     description: 'A description of the Legacy edX Discussions app.',
   },
   // Piazza
   'appName-piazza': {
-    id: 'authoring.discussions.appName-piazza',
+    id: 'authoring.discussions.appList.appName-piazza',
     defaultMessage: 'Piazza',
     description: 'The name of the Piazza app.',
   },
   'appDescription-piazza': {
-    id: 'authoring.discussions.appDescription-piazza',
+    id: 'authoring.discussions.appList.appDescription-piazza',
     defaultMessage: 'Piazza is designed to connect students, TAs, and professors so every student can get the help they need when they need it.',
     description: 'A description of the Piazza app.',
   },

--- a/src/pages-and-resources/discussions/messages.js
+++ b/src/pages-and-resources/discussions/messages.js
@@ -34,9 +34,9 @@ const messages = defineMessages({
     defaultMessage: 'Applied',
     description: 'Button label when the discussion configuration has been successfully submitted.',
   },
-  selectDiscussionTool: {
-    id: 'authoring.discussions.selectDiscussionTool',
-    defaultMessage: 'Select discussion tool',
+  providerSelection: {
+    id: 'authoring.discussions.providerSelection',
+    defaultMessage: 'Provider selection',
     description: 'A label for the first step of a wizard where the user chooses a discussion tool to configure.',
   },
 });


### PR DESCRIPTION
This fixes three issues:

1. The Stepper's first step was named incorrectly, it should be "Provider selection"
2. The form title should be inside the card and smaller
3. There should be horizontal dividers between all sections of the LegacyConfigForm, and one at the top of the LtiConfigForm.

This fixes or addresses parts of:

https://openedx.atlassian.net/browse/TNL-8119 - step names
https://openedx.atlassian.net/browse/TNL-8136 - dividers between card sections
https://openedx.atlassian.net/browse/TNL-8127 - headers above cards on step 2
