### PR TITLE
Fixed card styles

### DIFF
--- a/src/pages-and-resources/discussions/app-list/AppCard.jsx
+++ b/src/pages-and-resources/discussions/app-list/AppCard.jsx
@@ -29,19 +29,19 @@ function AppCard({
       })}
     >
       <div
-        className="position-absolute"
+        className="position-absolute mt-3 mr-3"
         style={{
           top: '0.75rem',
           right: '0.75rem',
         }}
       >
-        <Input readOnly type="checkbox" checked={selected} />
+        <Input readOnly type="checkbox" style={{ width: '18px', height: '18px' }} checked={selected} />
       </div>
-      <Card.Body>
-        <Card.Title>
+      <Card.Body className="m-2">
+        <div className="h4 card-title">
           {intl.formatMessage(messages[`appName-${app.id}`])}
-        </Card.Title>
-        <Card.Subtitle className="mb-2 text-muted">{supportText}</Card.Subtitle>
+        </div>
+        <Card.Subtitle className="mb-3 text-muted">{supportText}</Card.Subtitle>
         <Card.Text>{intl.formatMessage(messages[`appDescription-${app.id}`])}</Card.Text>
       </Card.Body>
     </Card>

--- a/src/pages-and-resources/discussions/app-list/messages.js
+++ b/src/pages-and-resources/discussions/app-list/messages.js
@@ -3,7 +3,7 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 const messages = defineMessages({
   heading: {
     id: 'authoring.discussions.heading',
-    defaultMessage: 'Which discussion tool would you like to use for this course?',
+    defaultMessage: 'Select a discussion tool for this course',
   },
   supportedFeatures: {
     id: 'authoring.discussions.supportedFeatures',


### PR DESCRIPTION
[TNL-8110](https://openedx.atlassian.net/browse/TNL-8110)

Updated card styles to match the Figma hifi. Also updated the text to match figma hifi.

Figma expected card style:
<img width="928" alt="Screenshot 2021-04-09 at 4 25 58 PM" src="https://user-images.githubusercontent.com/10988308/114204117-42256300-9972-11eb-9660-d3327b3363f9.png">


After changes

<img width="1262" alt="Screenshot 2021-04-09 at 5 27 37 PM" src="https://user-images.githubusercontent.com/10988308/114180261-69236b00-9959-11eb-8cc0-dbffa6aa00ed.png">
