### PR TITLE
Fixed heading styles

### DIFF
--- a/src/pages-and-resources/discussions/app-list/AppList.jsx
+++ b/src/pages-and-resources/discussions/app-list/AppList.jsx
@@ -40,7 +40,9 @@ function AppList({ courseId, intl }) {
 
   return (
     <div className="m-5">
-      <h2 className="my-4 text-center">{intl.formatMessage(messages.heading)}</h2>
+      <h3 className="my-4">
+        {intl.formatMessage(messages.heading)}
+      </h3>
       <CardGrid
         columnSizes={{
           xs: 12,
@@ -58,9 +60,9 @@ function AppList({ courseId, intl }) {
         ))}
       </CardGrid>
 
-      <h2 className="my-3">
+      <h3 className="my-3">
         {intl.formatMessage(messages.supportedFeatures)}
-      </h2>
+      </h3>
 
       <FeaturesTable
         apps={apps}


### PR DESCRIPTION
[TNL-8109](https://openedx.atlassian.net/browse/TNL-8109)

Updated heading styles to match the figma hifi. 

Figma expected headline
<img width="822" alt="Screenshot 2021-04-09 at 5 41 02 PM" src="https://user-images.githubusercontent.com/10988308/114203468-a4ca2f00-9971-11eb-83fe-983d744b150d.png">
<img width="768" alt="Screenshot 2021-04-09 at 5 41 08 PM" src="https://user-images.githubusercontent.com/10988308/114203486-a85db600-9971-11eb-9cee-1a3d51243271.png">

Outcome after change:
<img width="1389" alt="Screenshot 2021-04-09 at 5 57 49 PM" src="https://user-images.githubusercontent.com/10988308/114183632-50b54f80-995d-11eb-83f7-45dadb54e3bd.png">

