### PR TITLE
Added feature not available icon

### DIFF
--- a/src/pages-and-resources/discussions/app-list/FeaturesTable.jsx
+++ b/src/pages-and-resources/discussions/app-list/FeaturesTable.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { Remove } from '@edx/paragon/icons';
 import { DataTable } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import messages from './messages';
@@ -21,7 +22,9 @@ function FeaturesTable({ apps, features, intl }) {
             <div key={`${app.id}&${feature.id}`}>
               <FontAwesomeIcon icon={faCheck} />
             </div>
-          ) : null;
+          ) : (
+            <div key={`${app.id}&${feature.id}`}><Remove /></div>
+          );
         });
 
         return {


### PR DESCRIPTION
[TNL-8123](https://openedx.atlassian.net/browse/TNL-8123)

Display remove icon in case feature is not available. Currently if a feature is available it displays a check icon and if it is not available it does not display anything.

Currently:
<img width="1376" alt="Screenshot 2021-04-14 at 4 07 37 PM" src="https://user-images.githubusercontent.com/10988308/114700964-a4e47900-9d3b-11eb-8b8a-257187dda2c0.png">



Figma design (expected):
<img width="709" alt="Screenshot 2021-04-14 at 3 51 42 PM" src="https://user-images.githubusercontent.com/10988308/114699371-a614a680-9d39-11eb-958d-c58c93d129fe.png">



Outcome after change:
<img width="1407" alt="Screenshot 2021-04-14 at 3 52 15 PM" src="https://user-images.githubusercontent.com/10988308/114699397-ae6ce180-9d39-11eb-865d-1039e8df9cb0.png">




