### PR TITLE
style: margins removed from footer buttons.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3468,9 +3468,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "14.11.2",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.11.2.tgz",
-      "integrity": "sha512-2DBC1/3PUwZ7hcGRjT0dGVC5C66TL0Tx/yBEEbjRtQ8BDfiubGizE7wlUYC9VCWhVQgCOwpU5VRHztvp+XRX8A==",
+      "version": "14.11.4",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.11.4.tgz",
+      "integrity": "sha512-MDDrpcz+hjf7umaFjk6qs4oX5q1RI6v/rclOPLBS6r+84nO7Q0Av+0bbRzm8YfFdO5y6tKT8k4oGJefnRtT7hA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -5676,9 +5676,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.5",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.5.tgz",
-      "integrity": "sha512-bj4biDB9ZJmGAYTWSKJly6bMr4BLUiBrx9ujiJEoP9XIDY9CTaPGxE5QWN/1WjpPLzYF7/jRNnV2nNxNe970sw==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.6.tgz",
+      "integrity": "sha512-u/TtPoF/hrvb63LdukET6ncaplYsvCvmkceasx8oG84/ZCsoLxz9Z/raPBP4lTAiWW1Jb889Y9svHmv8R26dWw==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.0.11",
     "@edx/frontend-platform": "1.9.0",
-    "@edx/paragon": "14.11.2",
+    "@edx/paragon": "14.11.4",
     "@fortawesome/fontawesome-svg-core": "1.2.28",
     "@fortawesome/free-brands-svg-icons": "5.11.2",
     "@fortawesome/free-regular-svg-icons": "5.11.2",

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
@@ -26,7 +26,6 @@ function AppConfigFormSaveButton({ intl }) {
         complete: intl.formatMessage(messages.savedButton),
       }}
       state={submitButtonState}
-      className="mr-2"
       onClick={handleSave}
     />
   );

--- a/src/pages-and-resources/discussions/app-list/AppListNextButton.jsx
+++ b/src/pages-and-resources/discussions/app-list/AppListNextButton.jsx
@@ -20,7 +20,6 @@ function AppListNextButton({ intl }) {
     <Button
       variant="primary"
       onClick={handleStartConfig}
-      className="mr-2"
     >
       {intl.formatMessage(messages.nextButton)}
     </Button>


### PR DESCRIPTION
- Removed unnecessary margins from buttons.
This pr originally contained design fixes for header/footer/stepper but after integrating stepper from paragon those changes become invalid, hence only these classes applied on next/apply buttons which were serving no purpose are removed from code.

- bumped paragon version to 14.11.4
screen after version update is attached

<img width="1550" alt="Screenshot 2021-05-19 at 10 04 59 PM" src="https://user-images.githubusercontent.com/67791278/118854713-6d468f00-b8ee-11eb-8c88-b88faaf54578.png">
