### PR TITLE
test: Use the standard data-testid attribute instead of a custom one

### DIFF
--- a/src/generic/Loading.jsx
+++ b/src/generic/Loading.jsx
@@ -9,7 +9,7 @@ export default function Loading() {
       style={{
         height: '50vh',
       }}
-      data-test-id="spinnerContainer"
+      data-testid="spinnerContainer"
     >
       <Spinner className animation="border" role="status" variant="primary">
         <span className="sr-only">

--- a/src/proctored-exam-settings/ProctoredExamSettings.jsx
+++ b/src/proctored-exam-settings/ProctoredExamSettings.jsx
@@ -117,7 +117,7 @@ function ProctoredExamSettings({ courseId, intl }) {
           isValid: false,
           errors: {
             formProctortrackEscalationEmail: {
-              dialogErrorMessage: (<Alert.Link onClick={setFocusToProctortrackEscalationEmailInput} href="#formProctortrackEscalationEmail" data-test-id="proctorTrackEscalationEmailErrorLink">{errorMessage}</Alert.Link>),
+              dialogErrorMessage: (<Alert.Link onClick={setFocusToProctortrackEscalationEmailInput} href="#formProctortrackEscalationEmail" data-testid="proctorTrackEscalationEmailErrorLink">{errorMessage}</Alert.Link>),
               inputErrorMessage: errorMessage,
             },
           },
@@ -129,7 +129,7 @@ function ProctoredExamSettings({ courseId, intl }) {
           isValid: false,
           errors: {
             formProctortrackEscalationEmail: {
-              dialogErrorMessage: (<Alert.Link onClick={setFocusToProctortrackEscalationEmailInput} href="#formProctortrackEscalationEmail" data-test-id="proctorTrackEscalationEmailErrorLink">{errorMessage}</Alert.Link>),
+              dialogErrorMessage: (<Alert.Link onClick={setFocusToProctortrackEscalationEmailInput} href="#formProctortrackEscalationEmail" data-testid="proctorTrackEscalationEmailErrorLink">{errorMessage}</Alert.Link>),
               inputErrorMessage: errorMessage,
             },
           },
@@ -168,7 +168,7 @@ function ProctoredExamSettings({ courseId, intl }) {
         key={provider}
         value={provider}
         disabled={isDisabledOption(provider)}
-        data-test-id={provider}
+        data-testid={provider}
       >
         {provider}
       </option>
@@ -192,7 +192,7 @@ function ProctoredExamSettings({ courseId, intl }) {
 
   function renderContent() {
     return (
-      <Form onSubmit={handleSubmit} data-test-id="proctoringForm">
+      <Form onSubmit={handleSubmit} data-testid="proctoringForm">
         {!formStatus.isValid && formStatus.errors.formProctortrackEscalationEmail
           && (
             // tabIndex="-1" to make non-focusable element focusable
@@ -200,7 +200,7 @@ function ProctoredExamSettings({ courseId, intl }) {
               id="proctortrackEscalationEmailError"
               variant="danger"
               tabIndex="-1"
-              data-test-id="proctortrackEscalationEmailError"
+              data-testid="proctortrackEscalationEmailError"
               ref={alertRef}
             >
               {getFormErrorMessage()}
@@ -245,7 +245,7 @@ function ProctoredExamSettings({ courseId, intl }) {
                 inline
                 checked={allowOptingOut}
                 onChange={() => onAllowOptingOutChange(true)}
-                data-test-id="allowOptingOutYes"
+                data-testid="allowOptingOutYes"
               />
               <Form.Check
                 type="radio"
@@ -255,7 +255,7 @@ function ProctoredExamSettings({ courseId, intl }) {
                 inline
                 checked={!allowOptingOut}
                 onChange={() => onAllowOptingOutChange(false)}
-                data-test-id="allowOptingOutNo"
+                data-testid="allowOptingOutNo"
               />
               <Form.Text id="allowOptingOutHelpText">
                 <FormattedMessage
@@ -308,7 +308,7 @@ function ProctoredExamSettings({ courseId, intl }) {
             <Form.Control
               ref={proctoringEscalationEmailInputRef}
               type="email"
-              data-test-id="escalationEmail"
+              data-testid="escalationEmail"
               onChange={onProctortrackEscalationEmailChange}
               value={proctortrackEscalationEmail}
               isInvalid={Object.prototype.hasOwnProperty.call(formStatus.errors, 'formProctortrackEscalationEmail')}
@@ -346,7 +346,7 @@ function ProctoredExamSettings({ courseId, intl }) {
                 name="createZendeskTickets"
                 checked={createZendeskTickets}
                 onChange={() => onCreateZendeskTicketsChange(true)}
-                data-test-id="createZendeskTicketsYes"
+                data-testid="createZendeskTicketsYes"
               />
               <Form.Check
                 type="radio"
@@ -356,7 +356,7 @@ function ProctoredExamSettings({ courseId, intl }) {
                 name="createZendeskTickets"
                 checked={!createZendeskTickets}
                 onChange={() => onCreateZendeskTicketsChange(false)}
-                data-test-id="createZendeskTicketsNo"
+                data-testid="createZendeskTicketsNo"
               />
               <Form.Text id="createZendeskTicketsText">
                 <FormattedMessage
@@ -371,7 +371,7 @@ function ProctoredExamSettings({ courseId, intl }) {
         <Button
           variant="primary"
           className="mb-3"
-          data-test-id="submissionButton"
+          data-testid="submissionButton"
           type="submit"
           disabled={submissionInProgress}
         >
@@ -381,7 +381,7 @@ function ProctoredExamSettings({ courseId, intl }) {
             description="Form submit button"
           />
         </Button> {' '}
-        {submissionInProgress && <Spinner animation="border" variant="primary" data-test-id="saveInProgress" aria-label="Save in progress" />}
+        {submissionInProgress && <Spinner animation="border" variant="primary" data-testid="saveInProgress" aria-label="Save in progress" />}
       </Form>
     );
   }
@@ -394,7 +394,7 @@ function ProctoredExamSettings({ courseId, intl }) {
 
   function renderConnectionError() {
     return (
-      <Alert variant="danger" data-test-id="connectionError">
+      <Alert variant="danger" data-testid="connectionError">
         <FormattedMessage
           id="authoring.examsettings.alert.error.connection"
           defaultMessage={`
@@ -410,7 +410,7 @@ function ProctoredExamSettings({ courseId, intl }) {
 
   function renderPermissionError() {
     return (
-      <Alert variant="danger" data-test-id="permissionError">
+      <Alert variant="danger" data-testid="permissionError">
         <FormattedMessage
           id="authoring.examsettings.alert.error.permission"
           defaultMessage={`
@@ -428,7 +428,7 @@ function ProctoredExamSettings({ courseId, intl }) {
       <Alert
         variant="success"
         dismissible
-        data-test-id="saveSuccess"
+        data-testid="saveSuccess"
         tabIndex="-1"
         ref={saveStatusAlertRef}
         onClose={() => setSaveSuccess(false)}
@@ -450,7 +450,7 @@ function ProctoredExamSettings({ courseId, intl }) {
       <Alert
         variant="danger"
         dismissible
-        data-test-id="saveError"
+        data-testid="saveError"
         tabIndex="-1"
         ref={saveStatusAlertRef}
         onClose={() => setSaveError(false)}

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,7 +1,4 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-import { configure } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import '@testing-library/jest-dom/extend-expect';
-
-configure({ testIdAttribute: 'data-test-id' });

--- a/src/studio-header/Header.jsx
+++ b/src/studio-header/Header.jsx
@@ -108,8 +108,8 @@ function Header({
       href={`${config.STUDIO_BASE_URL}/course/${courseId}`}
       aria-label={intl.formatMessage(messages['header.label.courseOutline'])}
     >
-      <span className="d-block small m-0" data-test-id="course-org-number">{courseOrg} {courseNumber}</span>
-      <span className="d-block m-0 font-weight-bold" data-test-id="course-title">{courseTitle}</span>
+      <span className="d-block small m-0" data-testid="course-org-number">{courseOrg} {courseNumber}</span>
+      <span className="d-block m-0 font-weight-bold" data-testid="course-title">{courseTitle}</span>
     </a>
   );
 


### PR DESCRIPTION
We don’t have any need for a custom data-testid attribute, so removing it so it matches documentation and doesn’t confuse future testers.