### PR TITLE
feat: Add UI for Add Topics

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-transition-group": "4.4.1",
     "redux": "4.0.5",
     "regenerator-runtime": "0.13.7",
+    "uuid": "^3.4.0",
     "yup": "0.31.1"
   },
   "devDependencies": {

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
@@ -7,7 +7,7 @@ import { useRouteMatch } from 'react-router';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { Container } from '@edx/paragon';
 
-import { useModel } from '../../../generic/model-store';
+import { useModel, useModels } from '../../../generic/model-store';
 import { PagesAndResourcesContext } from '../../PagesAndResourcesProvider';
 import {
   FAILED, LOADED, LOADING, selectApp,
@@ -29,12 +29,16 @@ function AppConfigForm({
   const { formRef } = useContext(AppConfigFormContext);
   const { path: pagesAndResourcesPath } = useContext(PagesAndResourcesContext);
   const { params: { appId: routeAppId } } = useRouteMatch();
-  const { selectedAppId, status, saveStatus } = useSelector(state => state.discussions);
+  const {
+    selectedAppId, status, saveStatus, discussionTopicIds,
+  } = useSelector(state => state.discussions);
   const app = useModel('apps', selectedAppId);
   // appConfigs have no ID of their own, so we use the active app ID to reference them.
   // This appConfig may come back as null if the selectedAppId is not the activeAppId, i.e.,
   // if we're configuring a new app.
-  const appConfig = useModel('appConfigs', selectedAppId);
+  const appConfigObj = useModel('appConfigs', selectedAppId);
+  const discussionTopics = useModels('discussionTopics', discussionTopicIds);
+  const appConfig = { ...appConfigObj, discussionTopics };
 
   useEffect(() => {
     if (status === LOADED) {

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
@@ -30,7 +30,24 @@ function LegacyConfigForm({
               Yup.object().shape({
                 name: Yup.string().required(intl.formatMessage(messages.discussionTopicRequired)),
               }),
-            ),
+            ).test('unique', (
+              list,
+              testContext,
+              message = intl.formatMessage(messages.discussionTopicNameAlreadyExist),
+            ) => {
+              const mapper = x => x.name;
+              const set = [...new Set(list.map(mapper))];
+              const isUnique = list.length === set.length;
+              if (isUnique) {
+                return true;
+              }
+
+              const idx = list.findIndex((l, i) => mapper(l) !== set[i]);
+              return testContext.createError({
+                path: `[${idx}].name`,
+                message,
+              });
+            }),
         })
       }
       onSubmit={(values) => (onSubmit(values))}

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
@@ -7,6 +7,7 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
 import DivisionByGroupFields from '../shared/DivisionByGroupFields';
 import AnonymousPostingFields from '../shared/AnonymousPostingFields';
+import DiscussionTopics from '../shared/discussion-topics/DiscussionTopics';
 import BlackoutDatesField, { blackoutDatesRegex } from '../shared/BlackoutDatesField';
 
 import messages from '../shared/messages';
@@ -48,6 +49,8 @@ function LegacyConfigForm({
           onChange={handleChange}
           values={values}
         />
+        <AppConfigFormDivider thick />
+        <DiscussionTopics />
         <AppConfigFormDivider thick />
         <BlackoutDatesField
           errors={errors}

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Card, Form } from '@edx/paragon';
-import { useFormik } from 'formik';
+import { Formik } from 'formik';
 import * as Yup from 'yup';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
@@ -16,50 +16,62 @@ import AppConfigFormDivider from '../shared/AppConfigFormDivider';
 function LegacyConfigForm({
   appConfig, onSubmit, formRef, intl, title,
 }) {
-  const {
-    handleSubmit,
-    handleChange,
-    handleBlur,
-    values,
-    errors,
-  } = useFormik({
-    initialValues: appConfig,
-    validationSchema: Yup.object().shape({
-      blackoutDates: Yup.string().matches(
-        blackoutDatesRegex,
-        intl.formatMessage(messages.blackoutDatesFormattingError),
-      ),
-    }),
-    onSubmit,
-  });
-
   return (
-    <Card className="mb-5 px-4 px-sm-5 pb-5" data-testid="legacyConfigForm">
-      <Form ref={formRef} onSubmit={handleSubmit}>
-        <h3 className="text-primary-500 my-3">{title}</h3>
-        <AppConfigFormDivider thick />
-        <AnonymousPostingFields
-          onBlur={handleBlur}
-          onChange={handleChange}
-          values={values}
-        />
-        <AppConfigFormDivider />
-        <DivisionByGroupFields
-          onBlur={handleBlur}
-          onChange={handleChange}
-          values={values}
-        />
-        <AppConfigFormDivider thick />
-        <DiscussionTopics />
-        <AppConfigFormDivider thick />
-        <BlackoutDatesField
-          errors={errors}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          values={values}
-        />
-      </Form>
-    </Card>
+    <Formik
+      initialValues={appConfig}
+      validationSchema={
+        Yup.object().shape({
+          blackoutDates: Yup.string().matches(
+            blackoutDatesRegex,
+            intl.formatMessage(messages.blackoutDatesFormattingError),
+          ),
+          discussionTopics: Yup.array()
+            .of(
+              Yup.object().shape({
+                name: Yup.string().required(intl.formatMessage(messages.discussionTopicRequired)),
+              }),
+            ),
+        })
+      }
+      onSubmit={(values) => (onSubmit(values))}
+    >
+      {(
+        {
+          handleSubmit,
+          handleChange,
+          handleBlur,
+          values,
+          errors,
+        },
+      ) => (
+        <Card className="mb-5 px-4 px-sm-5 pb-5" data-testid="legacyConfigForm">
+          <Form ref={formRef} onSubmit={handleSubmit}>
+            <h3 className="text-primary-500 my-3">{title}</h3>
+            <AppConfigFormDivider thick />
+            <AnonymousPostingFields
+              onBlur={handleBlur}
+              onChange={handleChange}
+              values={values}
+            />
+            <AppConfigFormDivider />
+            <DivisionByGroupFields
+              onBlur={handleBlur}
+              onChange={handleChange}
+              values={values}
+            />
+            <AppConfigFormDivider thick />
+            <DiscussionTopics />
+            <AppConfigFormDivider thick />
+            <BlackoutDatesField
+              errors={errors}
+              onBlur={handleBlur}
+              onChange={handleChange}
+              values={values}
+            />
+          </Form>
+        </Card>
+      )}
+    </Formik>
   );
 }
 
@@ -72,6 +84,7 @@ LegacyConfigForm.propTypes = {
     allowAnonymousPosts: PropTypes.bool.isRequired,
     allowAnonymousPostsPeers: PropTypes.bool.isRequired,
     blackoutDates: PropTypes.string.isRequired,
+    discussionTopics: PropTypes.arrayOf(PropTypes.object),
   }),
   onSubmit: PropTypes.func.isRequired,
   // eslint-disable-next-line react/forbid-prop-types

--- a/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/legacy/LegacyConfigForm.test.jsx
@@ -1,7 +1,21 @@
 import React, { createRef } from 'react';
 import { act, render } from '@testing-library/react';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { initializeMockApp } from '@edx/frontend-platform';
+import { AppProvider } from '@edx/frontend-platform/react';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import MockAdapter from 'axios-mock-adapter';
+
+import { getAppsUrl } from '../../../data/api';
+import { fetchApps } from '../../../data/thunks';
+import initializeStore from '../../../../../store';
+import executeThunk from '../../../../../utils';
+import {
+  legacyApiResponse,
+} from '../../../factories/mockApiResponses';
 import LegacyConfigForm from './LegacyConfigForm';
+
+const courseId = 'course-v1:edX+TestX+Test_Course';
 
 const defaultAppConfig = {
   id: 'legacy',
@@ -9,114 +23,149 @@ const defaultAppConfig = {
   divideCourseWideTopics: false,
   divideGeneralTopic: false,
   divideQuestionsForTAsTopic: false,
+  discussionTopics: [
+    { name: 'General', id: 'course-generated-id-123-client-made-this-up' },
+    { name: 'Edx', id: '13f106c6-6735-4e84-b097-0456cff55960' },
+  ],
   allowAnonymousPosts: false,
   allowAnonymousPostsPeers: false,
   blackoutDates: '[]',
 };
 
 describe('LegacyConfigForm', () => {
-  test('title rendering', () => {
-    const { container } = render(
-      <IntlProvider locale="en">
-        <LegacyConfigForm
-          title="Test Legacy edX Discussions"
-          appConfig={defaultAppConfig}
-          onSubmit={jest.fn()}
-          formRef={createRef()}
-        />
-      </IntlProvider>,
+  let axiosMock;
+  let store;
+  let container;
+
+  beforeEach(() => {
+    initializeMockApp({
+      authenticatedUser: {
+        userId: 3,
+        username: 'abc123',
+        administrator: true,
+        roles: [],
+      },
+    });
+
+    axiosMock = new MockAdapter(getAuthenticatedHttpClient());
+    store = initializeStore();
+  });
+
+  afterEach(() => {
+    axiosMock.reset();
+  });
+
+  const createComponent = (appConfig, onSubmit = jest.fn(), formRef = createRef()) => {
+    const wrapper = render(
+      <AppProvider store={store}>
+        <IntlProvider locale="en">
+          <LegacyConfigForm
+            title="Test Legacy edX Discussions"
+            appConfig={appConfig}
+            onSubmit={onSubmit}
+            formRef={formRef}
+          />
+        </IntlProvider>
+      </AppProvider>,
     );
+    container = wrapper.container;
+    return container;
+  };
+
+  const mockStore = async (mockResponse) => {
+    axiosMock.onGet(getAppsUrl(courseId)).reply(200, mockResponse);
+    await executeThunk(fetchApps(courseId), store.dispatch);
+  };
+
+  test('title rendering', async () => {
+    await mockStore(legacyApiResponse);
+    createComponent(defaultAppConfig);
 
     expect(container.querySelector('h3')).toHaveTextContent('Test Legacy edX Discussions');
   });
+
   test('calls onSubmit when the formRef is submitted', async () => {
     const formRef = createRef();
     const handleSubmit = jest.fn();
 
-    render(
-      <IntlProvider locale="en">
-        <LegacyConfigForm
-          title="Test Legacy edX Discussions"
-          appConfig={defaultAppConfig}
-          onSubmit={handleSubmit}
-          formRef={formRef}
-        />
-      </IntlProvider>,
-    );
+    await mockStore(legacyApiResponse);
+    createComponent(defaultAppConfig, handleSubmit, formRef);
 
     await act(async () => {
       formRef.current.submit();
     });
+
     expect(handleSubmit).toHaveBeenCalledWith(
       // Because we use defaultAppConfig as the initialValues of the form, and we haven't changed
       // any of the form inputs, this exact object shape is returned back to us, so we're reusing
       // it here.  It's not supposed to be 'the same object', it just happens to be.
       defaultAppConfig,
-      // The second argument is a Formik object with all sorts of functions on it which we don't
-      // care about.
-      expect.anything(),
     );
   });
 
-  test('default field states are correct, including removal of folded sub-fields', () => {
-    const { container } = render(
-      <IntlProvider locale="en">
-        <LegacyConfigForm
-          title="Test Legacy edX Discussions"
-          appConfig={defaultAppConfig}
-          onSubmit={jest.fn()}
-          formRef={createRef()}
-        />
-      </IntlProvider>,
-    );
+  test('default field states are correct, including removal of folded sub-fields', async () => {
+    await mockStore(legacyApiResponse);
+    createComponent(defaultAppConfig);
 
     // DivisionByGroupFields
     expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
     expect(container.querySelector('#divideByCohorts')).not.toBeChecked();
-    expect(container.querySelector('#divideCourseWideTopics')).not.toBeInTheDocument();
-    expect(container.querySelector('#divideGeneralTopic')).not.toBeInTheDocument();
-    expect(container.querySelector('#divideQuestionsForTAsTopic')).not.toBeInTheDocument();
+    expect(
+      container.querySelector('#divideCourseWideTopics'),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('#divideGeneralTopic'),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('#divideQuestionsForTAsTopic'),
+    ).not.toBeInTheDocument();
 
     // AnonymousPostingFields
     expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();
     expect(container.querySelector('#allowAnonymousPosts')).not.toBeChecked();
-    expect(container.querySelector('#allowAnonymousPostsPeers')).not.toBeInTheDocument();
+    expect(
+      container.querySelector('#allowAnonymousPostsPeers'),
+    ).not.toBeInTheDocument();
 
     // BlackoutDatesField
     expect(container.querySelector('#blackoutDates')).toBeInTheDocument();
     expect(container.querySelector('#blackoutDates')).toHaveValue('[]');
   });
 
-  test('folded sub-fields are in the DOM when parents are enabled', () => {
-    const { container } = render(
-      <IntlProvider locale="en">
-        <LegacyConfigForm
-          title="Test Legacy edX Discussions"
-          appConfig={{
-            ...defaultAppConfig,
-            divideByCohorts: true,
-            allowAnonymousPosts: true,
-          }}
-          onSubmit={jest.fn()}
-          formRef={createRef()}
-        />
-      </IntlProvider>,
-    );
+  test('folded sub-fields are in the DOM when parents are enabled', async () => {
+    await mockStore(legacyApiResponse);
+    createComponent({
+      ...defaultAppConfig,
+      divideByCohorts: true,
+      allowAnonymousPosts: true,
+    });
 
     // DivisionByGroupFields
     expect(container.querySelector('#divideByCohorts')).toBeInTheDocument();
     expect(container.querySelector('#divideByCohorts')).toBeChecked();
-    expect(container.querySelector('#divideCourseWideTopics')).toBeInTheDocument();
-    expect(container.querySelector('#divideCourseWideTopics')).not.toBeChecked();
+    expect(
+      container.querySelector('#divideCourseWideTopics'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('#divideCourseWideTopics'),
+    ).not.toBeChecked();
     expect(container.querySelector('#divideGeneralTopic')).toBeInTheDocument();
     expect(container.querySelector('#divideGeneralTopic')).not.toBeChecked();
-    expect(container.querySelector('#divideQuestionsForTAsTopic')).toBeInTheDocument();
-    expect(container.querySelector('#divideQuestionsForTAsTopic')).not.toBeChecked();
+    expect(
+      container.querySelector('#divideQuestionsForTAsTopic'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('#divideQuestionsForTAsTopic'),
+    ).not.toBeChecked();
 
     // AnonymousPostingFields
     expect(container.querySelector('#allowAnonymousPosts')).toBeInTheDocument();
     expect(container.querySelector('#allowAnonymousPosts')).toBeChecked();
-    expect(container.querySelector('#allowAnonymousPostsPeers')).toBeInTheDocument();
-    expect(container.querySelector('#allowAnonymousPostsPeers')).not.toBeChecked();
+    expect(
+      container.querySelector('#allowAnonymousPostsPeers'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('#allowAnonymousPostsPeers'),
+    ).not.toBeChecked();
   });
 });

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
@@ -1,27 +1,20 @@
-import { Collapsible, Form, Button } from '@edx/paragon';
+import React, { useState, useEffect } from 'react';
 import { Add } from '@edx/paragon/icons';
-import React, { useState } from 'react';
+import { Button } from '@edx/paragon';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { FieldArray, useFormikContext } from 'formik';
+import { v4 as uuid } from 'uuid';
+
 import messages from '../messages';
 import TopicItem from './TopicItem';
-import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 
-const newTopic = { id: 'unique-id', name: '' };
-const dataTopics = [
-  {
-    id: 'id-general',
-    name: 'General',
-  },
-  {
-    id: 'id-intro',
-    name: 'Introductoin',
-  },
-];
+const DiscussionTopics = ({ intl }) => {
+  const { values } = useFormikContext();
+  const [topics, setTopics] = useState(values.discussionTopics);
 
-function DiscussionTopics({ intl }) {
-  const [topics, setTopics] = useState(dataTopics);
-  const handleAddNewTopic = () => {
-    setTopics([...topics, newTopic]);
-  };
+  useEffect(() => {
+    setTopics(values.discussionTopics);
+  }, [values]);
 
   return (
     <>
@@ -34,26 +27,42 @@ function DiscussionTopics({ intl }) {
         structure. All courses have a general topic by default.
       </div>
       <div>
-        {topics.map((topic) => (
-          <TopicItem {...topic} key={`topic-${topic.id}`} />
-        ))}
-      </div>
+        <FieldArray
+          name="discussionTopics"
+          render={({ push, remove }) => (
+            <div>
+              {
+                topics.map((topic, index) => (
+                  <TopicItem
+                    {...topic}
+                    key={`topic-${topic.id}`}
+                    index={index}
+                    onDelete={(topicIndex) => remove(topicIndex)}
+                  />
+                ))
 
-      <div className="mb-3">
-        <Add />
-        <Button
-          onClick={handleAddNewTopic}
-          variant="link"
-          size="inline"
-          className="mr-1 text-primary-500"
-        >
-          Add topic
-        </Button>
+              }
+              <div className="mb-3">
+                <Add />
+                <Button
+                  onClick={() => push({ id: uuid(), name: '' })}
+                  variant="link"
+                  size="inline"
+                  className="mr-1 text-primary-500"
+                >
+                  Add topic
+                </Button>
+              </div>
+            </div>
+          )}
+        />
       </div>
     </>
   );
-}
+};
 
-DiscussionTopics.propTypes = {};
+DiscussionTopics.propTypes = {
+  intl: intlShape.isRequired,
+};
 
 export default injectIntl(DiscussionTopics);

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
@@ -30,7 +30,7 @@ const DiscussionTopics = ({ intl }) => {
     dispatch(removeModel({ modelType: 'discussionTopics', id: topicId }));
   };
 
-  const addNewtopic = (push) => {
+  const addNewTopic = (push) => {
     const payload = { name: '', id: uuid() };
     push(payload);
   };
@@ -43,7 +43,7 @@ const DiscussionTopics = ({ intl }) => {
       <label className="text-primary-500 mb-2 h4">
         {intl.formatMessage(messages.discussionTopicsLabel)}
       </label>
-      <div className="small mb-4 mt-0 text-muted">
+      <div className="small mb-4 text-muted">
         {intl.formatMessage(messages.discussionTopicsHelp)}
       </div>
       <div>
@@ -65,7 +65,7 @@ const DiscussionTopics = ({ intl }) => {
               <div className="mb-4">
                 <Add />
                 <Button
-                  onClick={() => addNewtopic(push)}
+                  onClick={() => addNewTopic(push)}
                   variant="link"
                   size="inline"
                   className="mr-1 text-primary-500"

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
@@ -22,7 +22,7 @@ const DiscussionTopics = ({ intl }) => {
 
     setTopics(values.discussionTopics);
     dispatch(updateDiscussionTopicIds(updatedDiscussionTopicIds));
-    dispatch(updatedDiscussionTopics(values));
+    dispatch(updatedDiscussionTopics(values.discussionTopics));
   }, [values.discussionTopics]);
 
   const handleTopicDelete = (topicIndex, topicId, remove) => {

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { Add } from '@edx/paragon/icons';
 import { Button } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
@@ -7,14 +8,32 @@ import { v4 as uuid } from 'uuid';
 
 import messages from '../messages';
 import TopicItem from './TopicItem';
+import { removeModel } from '../../../../../../generic/model-store';
+import { updateDiscussionTopicIds } from '../../../../data/slice';
+import { updatedDiscussionTopics } from '../../../../data/thunks';
 
 const DiscussionTopics = ({ intl }) => {
+  const dispatch = useDispatch();
   const { values } = useFormikContext();
   const [topics, setTopics] = useState(values.discussionTopics);
 
   useEffect(() => {
+    const updatedDiscussionTopicIds = values.discussionTopics?.map(topic => topic.id);
+
     setTopics(values.discussionTopics);
-  }, [values]);
+    dispatch(updateDiscussionTopicIds(updatedDiscussionTopicIds));
+    dispatch(updatedDiscussionTopics(values));
+  }, [values.discussionTopics]);
+
+  const handleTopicDelete = (topicIndex, topicId, remove) => {
+    remove(topicIndex);
+    dispatch(removeModel({ modelType: 'discussionTopics', id: topicId }));
+  };
+
+  const addNewtopic = (push) => {
+    const payload = { name: '', id: uuid() };
+    push(payload);
+  };
 
   return (
     <>
@@ -37,7 +56,7 @@ const DiscussionTopics = ({ intl }) => {
                     {...topic}
                     key={`topic-${topic.id}`}
                     index={index}
-                    onDelete={(topicIndex) => remove(topicIndex)}
+                    onDelete={() => handleTopicDelete(index, topic.id, remove)}
                   />
                 ))
 
@@ -45,7 +64,7 @@ const DiscussionTopics = ({ intl }) => {
               <div className="mb-3">
                 <Add />
                 <Button
-                  onClick={() => push({ id: uuid(), name: '' })}
+                  onClick={() => addNewtopic(push)}
                   variant="link"
                   size="inline"
                   className="mr-1 text-primary-500"

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
@@ -37,13 +37,14 @@ const DiscussionTopics = ({ intl }) => {
 
   return (
     <>
-      <h5 className="text-gray-500">
+      <h5 className="text-gray-500 mt-4 mb-2">
         {intl.formatMessage(messages.discussionTopics)}
       </h5>
-      <h4>General discussion topics</h4>
-      <div className="small mb-4">
-        Discussions can include general topics not contained to the course
-        structure. All courses have a general topic by default.
+      <label className="text-primary-500 mb-2 h4">
+        {intl.formatMessage(messages.discussionTopicsLabel)}
+      </label>
+      <div className="small mb-4 mt-0 text-muted">
+        {intl.formatMessage(messages.discussionTopicsHelp)}
       </div>
       <div>
         <FieldArray
@@ -61,7 +62,7 @@ const DiscussionTopics = ({ intl }) => {
                 ))
 
               }
-              <div className="mb-3">
+              <div className="mb-4">
                 <Add />
                 <Button
                   onClick={() => addNewtopic(push)}
@@ -69,7 +70,7 @@ const DiscussionTopics = ({ intl }) => {
                   size="inline"
                   className="mr-1 text-primary-500"
                 >
-                  Add topic
+                  {intl.formatMessage(messages.addTopicButton)}
                 </Button>
               </div>
             </div>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
@@ -1,0 +1,59 @@
+import { Collapsible, Form, Button } from '@edx/paragon';
+import { Add } from '@edx/paragon/icons';
+import React, { useState } from 'react';
+import messages from '../messages';
+import TopicItem from './TopicItem';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+
+const newTopic = { id: 'unique-id', name: '' };
+const dataTopics = [
+  {
+    id: 'id-general',
+    name: 'General',
+  },
+  {
+    id: 'id-intro',
+    name: 'Introductoin',
+  },
+];
+
+function DiscussionTopics({ intl }) {
+  const [topics, setTopics] = useState(dataTopics);
+  const handleAddNewTopic = () => {
+    setTopics([...topics, newTopic]);
+  };
+
+  return (
+    <>
+      <h5 className="text-gray-500">
+        {intl.formatMessage(messages.discussionTopics)}
+      </h5>
+      <h4>General discussion topics</h4>
+      <div className="small mb-4">
+        Discussions can include general topics not contained to the course
+        structure. All courses have a general topic by default.
+      </div>
+      <div>
+        {topics.map((topic) => (
+          <TopicItem {...topic} key={`topic-${topic.id}`} />
+        ))}
+      </div>
+
+      <div className="mb-3">
+        <Add />
+        <Button
+          onClick={handleAddNewTopic}
+          variant="link"
+          size="inline"
+          className="mr-1 text-primary-500"
+        >
+          Add topic
+        </Button>
+      </div>
+    </>
+  );
+}
+
+DiscussionTopics.propTypes = {};
+
+export default injectIntl(DiscussionTopics);

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   Collapsible, Form, Card, Button,
@@ -18,6 +18,11 @@ const TopicItem = ({
     touched,
     errors,
   } = useFormikContext();
+
+  useEffect(() => {
+    setTitle(name);
+  }, [name]);
+
   const isInvalidtopicNameKey = (
     (touched?.discussionTopics && touched.discussionTopics[index]?.name)
     && (errors?.discussionTopics && errors?.discussionTopics[index]?.name)
@@ -41,7 +46,7 @@ const TopicItem = ({
     }
   };
 
-  const handleDelete = (event) => {
+  const DeleteDiscussionTopic = (event) => {
     event.stopPropagation();
     setIsRemove(true);
   };
@@ -66,7 +71,7 @@ const TopicItem = ({
                 <Button
                   variant="outline-brand"
                   className="ml-2"
-                  onClick={() => onDelete(index)}
+                  onClick={() => onDelete()}
                 >
                   Delete
                 </Button>
@@ -93,7 +98,7 @@ const TopicItem = ({
                 {getHeading(true)}
                 {name !== 'General' && (
                   <div className="pr-4 border-right">
-                    <Delete onClick={handleDelete} />
+                    <Delete onClick={DeleteDiscussionTopic} />
                   </div>
                 )}
                 <div className="pl-4">

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import {
   Collapsible, Form, Card, Button,
 } from '@edx/paragon';
-import { injectIntl } from '@edx/frontend-platform/i18n';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { useFormikContext } from 'formik';
 import { ExpandLess, ExpandMore, Delete } from '@edx/paragon/icons';
+import messages from '../messages';
 
 const TopicItem = ({
-  index, name, onDelete,
+  intl, index, name, onDelete,
 }) => {
   const [title, setTitle] = useState(name);
   const [isRemove, setIsRemove] = useState(false);
@@ -26,6 +27,11 @@ const TopicItem = ({
   const isInvalidtopicNameKey = (
     (touched?.discussionTopics && touched.discussionTopics[index]?.name)
     && (errors?.discussionTopics && errors?.discussionTopics[index]?.name)
+  );
+
+  const isExistedName = (
+    (touched?.discussionTopics && touched.discussionTopics[index]?.name)
+    && (errors && errors[index]?.name)
   );
 
   const getHeading = (isOpen = false) => {
@@ -57,23 +63,25 @@ const TopicItem = ({
         isRemove ? (
           <Card className="rounded mb-3 p-1">
             <Card.Body>
-              <div className="h4 card-title">Delete this topic?</div>
-              <Card.Text className="text-gray-700 text-justify">
-                edX recommends that you do not delete discussion topics once your course is running.
+              <div className="text-primary-500 mb-2 h4">
+                {intl.formatMessage(messages.discussionTopicDeletionLabel)}
+              </div>
+              <Card.Text className="text-justify text-muted">
+                {intl.formatMessage(messages.discussionTopicDeletionHelp)}
               </Card.Text>
               <div className="d-flex justify-content-end">
                 <Button
                   variant="tertiary"
                   onClick={() => setIsRemove(false)}
                 >
-                  Cancel
+                  {intl.formatMessage(messages.cancelButton)}
                 </Button>
                 <Button
                   variant="outline-brand"
                   className="ml-2"
                   onClick={() => onDelete()}
                 >
-                  Delete
+                  {intl.formatMessage(messages.deleteButton)}
                 </Button>
               </div>
             </Card.Body>
@@ -122,12 +130,14 @@ const TopicItem = ({
                 />
                 {isInvalidtopicNameKey && (
                   <Form.Control.Feedback type="invalid" hasIcon={false}>
-                    <div className="small">Topic name is a required fields</div>
+                    <div className="small">
+                      {intl.formatMessage(messages.discussionTopicRequired)}
+                    </div>
                   </Form.Control.Feedback>
                 )}
-                {!isInvalidtopicNameKey && (
-                  <Form.Control.Feedback>
-                    <div className="small">Choose a unique name for your topic</div>
+                {isExistedName && (
+                  <Form.Control.Feedback type="invalid" hasIcon={false}>
+                    <div className="small">{isExistedName}</div>
                   </Form.Control.Feedback>
                 )}
               </Form.Group>
@@ -143,6 +153,7 @@ TopicItem.propTypes = {
   name: PropTypes.string.isRequired,
   index: PropTypes.number.isRequired,
   onDelete: PropTypes.func.isRequired,
+  intl: intlShape.isRequired,
 };
 
 export default injectIntl(TopicItem);

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -24,12 +24,12 @@ const TopicItem = ({
     setTitle(name);
   }, [name]);
 
-  const isInvalidtopicNameKey = Boolean(
+  const isInvalidTopicNameKey = Boolean(
     (touched.discussionTopics && touched.discussionTopics[index]?.name)
     && (errors.discussionTopics && errors?.discussionTopics[index]?.name),
   );
 
-  const isExistedName = Boolean(
+  const isExistingName = Boolean(
     (touched.discussionTopics && touched.discussionTopics[index]?.name)
     && (errors && errors[index]?.name),
   );
@@ -47,7 +47,7 @@ const TopicItem = ({
   };
 
   const handleToggle = (isOpen) => {
-    if (!isOpen && !isInvalidtopicNameKey) {
+    if (!isOpen && !isInvalidTopicNameKey) {
       setTitle(name);
     }
   };
@@ -119,7 +119,7 @@ const TopicItem = ({
             <Collapsible.Body className="collapsible-body rounded px-0">
               <Form.Group
                 controlId={`discussionTopics.${index}.name`}
-                isInvalid={isInvalidtopicNameKey}
+                isInvalid={isInvalidTopicNameKey}
                 className="m-2"
               >
                 <Form.Control
@@ -129,14 +129,14 @@ const TopicItem = ({
                   value={name}
                   controlClassName="bg-white"
                 />
-                {isInvalidtopicNameKey && (
+                {isInvalidTopicNameKey && (
                   <Form.Control.Feedback type="invalid" hasIcon={false}>
                     <div className="small">
                       {intl.formatMessage(messages.discussionTopicRequired)}
                     </div>
                   </Form.Control.Feedback>
                 )}
-                {isExistedName && (
+                {isExistingName && (
                   <Form.Control.Feedback type="invalid" hasIcon={false}>
                     <div className="small">
                       {intl.formatMessage(messages.discussionTopicNameAlreadyExist)}

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -12,7 +12,7 @@ const TopicItem = ({
   intl, index, name, onDelete,
 }) => {
   const [title, setTitle] = useState(name);
-  const [isRemove, setIsRemove] = useState(false);
+  const [showDeletePopup, setShowDeletePopup] = useState(false);
   const {
     handleChange,
     handleBlur,
@@ -52,40 +52,44 @@ const TopicItem = ({
     }
   };
 
-  const DeleteDiscussionTopic = (event) => {
+  const deleteDiscussionTopic = (event) => {
     event.stopPropagation();
-    setIsRemove(true);
+    setShowDeletePopup(true);
   };
+
+  const deletePopup = (
+    <Card className="rounded mb-3 p-1">
+      <Card.Body>
+        <div className="text-primary-500 mb-2 h4">
+          {intl.formatMessage(messages.discussionTopicDeletionLabel)}
+        </div>
+        <Card.Text className="text-justify text-muted">
+          {intl.formatMessage(messages.discussionTopicDeletionHelp)}
+        </Card.Text>
+        <div className="d-flex justify-content-end">
+          <Button
+            variant="tertiary"
+            onClick={() => setShowDeletePopup(false)}
+          >
+            {intl.formatMessage(messages.cancelButton)}
+          </Button>
+          <Button
+            variant="outline-brand"
+            className="ml-2"
+            onClick={() => onDelete()}
+          >
+            {intl.formatMessage(messages.deleteButton)}
+          </Button>
+        </div>
+      </Card.Body>
+    </Card>
+  );
 
   return (
     <>
       {
-        isRemove ? (
-          <Card className="rounded mb-3 p-1">
-            <Card.Body>
-              <div className="text-primary-500 mb-2 h4">
-                {intl.formatMessage(messages.discussionTopicDeletionLabel)}
-              </div>
-              <Card.Text className="text-justify text-muted">
-                {intl.formatMessage(messages.discussionTopicDeletionHelp)}
-              </Card.Text>
-              <div className="d-flex justify-content-end">
-                <Button
-                  variant="tertiary"
-                  onClick={() => setIsRemove(false)}
-                >
-                  {intl.formatMessage(messages.cancelButton)}
-                </Button>
-                <Button
-                  variant="outline-brand"
-                  className="ml-2"
-                  onClick={() => onDelete()}
-                >
-                  {intl.formatMessage(messages.deleteButton)}
-                </Button>
-              </div>
-            </Card.Body>
-          </Card>
+        showDeletePopup ? (
+          deletePopup
         ) : (
           <Collapsible.Advanced
             className="collapsible-card rounded mb-3 px-3 py-2"
@@ -104,11 +108,9 @@ const TopicItem = ({
               </Collapsible.Visible>
               <Collapsible.Visible whenOpen>
                 {getHeading(true)}
-                {name !== 'General' && (
-                  <div className="pr-4 border-right">
-                    <Delete onClick={DeleteDiscussionTopic} />
-                  </div>
-                )}
+                <div className="pr-4 border-right">
+                  <Delete onClick={deleteDiscussionTopic} />
+                </div>
                 <div className="pl-4">
                   <ExpandLess />
                 </div>
@@ -125,7 +127,6 @@ const TopicItem = ({
                   onChange={handleChange}
                   onBlur={handleBlur}
                   value={name}
-                  readOnly={name === 'General'}
                   controlClassName="bg-white"
                 />
                 {isInvalidtopicNameKey && (

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -1,0 +1,100 @@
+import { Collapsible, Form } from '@edx/paragon';
+import React, { useState } from 'react';
+import messages from '../messages';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { useFormik } from 'formik';
+import * as Yup from 'yup';
+import { ExpandLess, ExpandMore } from '@edx/paragon/icons';
+
+function TopicItem({ name, intl }) {
+  const {
+    handleSubmit,
+    data,
+    handleChange,
+    handleBlur,
+    values,
+    touched,
+    errors,
+    validateForm,
+  } = useFormik({
+    initialValues: { topicNameKey: name },
+    validationSchema: Yup.object().shape({
+      topicNameKey: Yup.string()
+        .required
+        // intl.formatMessage('lahore is missing'),
+        (),
+    }),
+  });
+  const [title, setTitle] = useState(name);
+  const isInvalidtopicNameKey = !!(touched.topicNameKey && errors.topicNameKey);
+  const isNewTopic = title === '';
+
+  const getHeading = (isOpen = false) => {
+    if (isNewTopic) {
+      return <span className="h4 p-2">Configure topic</span>;
+    }
+    if (isOpen) {
+      return <span className="h4 p-2">Rename {title} topic</span>;
+    }
+    return <span className="p-2">{title}</span>;
+  };
+
+  const handleToggle = (isOpen) => {
+    console.log('Collapsible toggled and open is: ', isOpen);
+    if (!isOpen && !isInvalidtopicNameKey) {
+      setTitle(values.topicNameKey);
+    }
+  };
+  
+  return (
+    <>
+      <Collapsible.Advanced
+        className="collapsible-card rounded mb-3"
+        onToggle={handleToggle}
+        defaultOpen={isNewTopic}
+      >
+        <Collapsible.Trigger className="collapsible-trigger d-flex border-0">
+          <Collapsible.Visible whenClosed>
+            {getHeading(false)}
+            <div>
+              <ExpandMore />
+            </div>
+          </Collapsible.Visible>
+          <Collapsible.Visible whenOpen>
+            {getHeading(true)}
+            <ExpandLess />
+          </Collapsible.Visible>
+        </Collapsible.Trigger>
+        <Collapsible.Body className="collapsible-body rounded">
+          <Form.Group
+            controlId="topicNameKey"
+            isInvalid={isInvalidtopicNameKey}
+            className="m-2"
+            size="sm"
+          >
+            <Form.Control
+              floatingLabel="Topic name"
+              onChange={handleChange}
+              onBlur={handleBlur}
+              value={values.topicNameKey}
+            />
+            {isInvalidtopicNameKey && (
+              <Form.Control.Feedback type="invalid" hasIcon={false}>
+                <div className="small">Topic name is a required fields</div>
+              </Form.Control.Feedback>
+            )}
+            {!isInvalidtopicNameKey && (
+              <Form.Control.Feedback>
+                <div className="small">Choose a unique name for your topic</div>
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+        </Collapsible.Body>
+      </Collapsible.Advanced>
+    </>
+  );
+}
+
+TopicItem.propTypes = {};
+
+export default injectIntl(TopicItem);

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -24,14 +24,14 @@ const TopicItem = ({
     setTitle(name);
   }, [name]);
 
-  const isInvalidtopicNameKey = (
-    (touched?.discussionTopics && touched.discussionTopics[index]?.name)
-    && (errors?.discussionTopics && errors?.discussionTopics[index]?.name)
+  const isInvalidtopicNameKey = Boolean(
+    (touched.discussionTopics && touched.discussionTopics[index]?.name)
+    && (errors.discussionTopics && errors?.discussionTopics[index]?.name),
   );
 
-  const isExistedName = (
-    (touched?.discussionTopics && touched.discussionTopics[index]?.name)
-    && (errors && errors[index]?.name)
+  const isExistedName = Boolean(
+    (touched.discussionTopics && touched.discussionTopics[index]?.name)
+    && (errors && errors[index]?.name),
   );
 
   const getHeading = (isOpen = false) => {
@@ -57,7 +57,7 @@ const TopicItem = ({
     setShowDeletePopup(true);
   };
 
-  const deletePopup = (
+  const deletetopic = (
     <Card className="rounded mb-3 p-1">
       <Card.Body>
         <div className="text-primary-500 mb-2 h4">
@@ -89,7 +89,7 @@ const TopicItem = ({
     <>
       {
         showDeletePopup ? (
-          deletePopup
+          deletetopic
         ) : (
           <Collapsible.Advanced
             className="collapsible-card rounded mb-3 px-3 py-2"
@@ -138,7 +138,9 @@ const TopicItem = ({
                 )}
                 {isExistedName && (
                   <Form.Control.Feedback type="invalid" hasIcon={false}>
-                    <div className="small">{isExistedName}</div>
+                    <div className="small">
+                      {intl.formatMessage(messages.discussionTopicNameAlreadyExist)}
+                    </div>
                   </Form.Control.Feedback>
                 )}
               </Form.Group>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
@@ -102,10 +102,46 @@ const messages = defineMessages({
     id: 'authoring.discussions.discussionTopics',
     defaultMessage: 'Discussion topics',
   },
+  discussionTopicsLabel: {
+    id: 'authoring.discussions.discussionTopics.label',
+    defaultMessage: 'General discussion topics',
+  },
+  discussionTopicsHelp: {
+    id: 'authoring.discussions.discussionTopics.help',
+    defaultMessage: 'Discussions can include general topics not contained to the course structure. All courses have a general topic by default.',
+  },
   discussionTopicRequired: {
     id: 'authoring.discussions.discussionTopic.required',
     defaultMessage: 'Topic name is a required field',
     description: 'Tells the user that the discussion topic field is required and must have a value.',
+  },
+  discussionTopicNameAlreadyExist: {
+    id: 'authoring.discussions.discussionTopic.alreadyExistError',
+    defaultMessage: 'It looks like this name is already in use',
+    description: 'Tells the user that the discussion topic name already in use and must have a unique name.',
+  },
+  addTopicButton: {
+    id: 'authoring.discussions.addTopicButton',
+    defaultMessage: 'Add Topic',
+    description: 'Button label when Add a new discussion topic.',
+  },
+  deleteButton: {
+    id: 'authoring.discussions.deleteButton',
+    defaultMessage: 'Delete',
+    description: 'Button label when delete discussion topic from conformation card.',
+  },
+  cancelButton: {
+    id: 'authoring.discussions.cancelButton',
+    defaultMessage: 'Cancel',
+    description: 'Button label when cancel discussion topic deletion conformation.',
+  },
+  discussionTopicDeletionHelp: {
+    id: 'authoring.discussions.discussionTopicDeletion.help',
+    defaultMessage: ' edX recommends that you do not delete discussion topics once your course is running.',
+  },
+  discussionTopicDeletionLabel: {
+    id: 'authoring.discussions.discussionTopicDeletion.label',
+    defaultMessage: 'Delete this topic?',
   },
   // Blackout dates
   blackoutDates: {

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
@@ -97,6 +97,11 @@ const messages = defineMessages({
     defaultMessage: 'Enter true or false. If true, students can create discussion posts that are anonymous to other students. This setting does not make posts anonymous to course staff.',
   },
 
+  // Discussion Topics
+  discussionTopics: {
+    id: 'authoring.discussions.discussionTopics',
+    defaultMessage: 'Discussion topics',
+  },
   // Blackout dates
   blackoutDates: {
     id: 'authoring.discussions.blackoutDates',

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
@@ -105,10 +105,12 @@ const messages = defineMessages({
   discussionTopicsLabel: {
     id: 'authoring.discussions.discussionTopics.label',
     defaultMessage: 'General discussion topics',
+    description: 'Label for a discussion topic section allowing a user to add new topic.',
   },
   discussionTopicsHelp: {
     id: 'authoring.discussions.discussionTopics.help',
     defaultMessage: 'Discussions can include general topics not contained to the course structure. All courses have a general topic by default.',
+    description: 'Help text for adding new discussion topics that in general discussion topic section.',
   },
   discussionTopicRequired: {
     id: 'authoring.discussions.discussionTopic.required',
@@ -138,10 +140,12 @@ const messages = defineMessages({
   discussionTopicDeletionHelp: {
     id: 'authoring.discussions.discussionTopicDeletion.help',
     defaultMessage: ' edX recommends that you do not delete discussion topics once your course is running.',
+    description: 'Help text for delete a discussion topic from discussion topic section.',
   },
   discussionTopicDeletionLabel: {
     id: 'authoring.discussions.discussionTopicDeletion.label',
     defaultMessage: 'Delete this topic?',
+    description: 'Label for discussion topic delete popup allowing a user to delete a topic.',
   },
   // Blackout dates
   blackoutDates: {

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
@@ -102,6 +102,11 @@ const messages = defineMessages({
     id: 'authoring.discussions.discussionTopics',
     defaultMessage: 'Discussion topics',
   },
+  discussionTopicRequired: {
+    id: 'authoring.discussions.discussionTopic.required',
+    defaultMessage: 'Topic name is a required field',
+    description: 'Tells the user that the discussion topic field is required and must have a value.',
+  },
   // Blackout dates
   blackoutDates: {
     id: 'authoring.discussions.blackoutDates',

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -22,6 +22,13 @@ function normalizeDiscussionTopic(data) {
   ));
 }
 
+function extractDiscussionTopicIds(data) {
+  return Object.entries(
+    data,
+    // eslint-disable-next-line no-unused-vars
+  ).map(([key, value]) => value.id);
+}
+
 function normalizePluginConfig(data) {
   if (!data || Object.keys(data).length < 1) {
     return {};
@@ -66,11 +73,10 @@ function normalizeApps(data) {
     },
     activeAppId: data.providers.active,
     apps,
-    discussionTopicIds: Object.entries(
-      data.plugin_configuration.discussion_topics,
-    // eslint-disable-next-line no-unused-vars
-    ).map(([key, value]) => value.id),
-    discussionTopics: normalizeDiscussionTopic(data.plugin_configuration.discussion_topics),
+    discussionTopicIds: data.plugin_configuration.discussion_topics
+      ? extractDiscussionTopicIds(data.plugin_configuration.discussion_topics) : [],
+    discussionTopics: data.plugin_configuration.discussion_topics
+      ? normalizeDiscussionTopic(data.plugin_configuration.discussion_topics) : [],
   };
 }
 
@@ -95,7 +101,7 @@ function denormalizeData(courseId, appId, data) {
   if (data.blackoutDates) {
     pluginConfiguration.discussion_blackouts = JSON.parse(data.blackoutDates);
   }
-  if (data.discussionTopics.length) {
+  if (data.discussionTopics?.length) {
     pluginConfiguration.discussion_topics = data.discussionTopics.reduce((topics, currentTopic) => {
       const newTopics = { ...topics };
       newTopics[currentTopic.name] = { id: currentTopic.id };

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -13,6 +13,15 @@ function normalizeLtiConfig(data) {
   };
 }
 
+function normalizeDiscussionTopic(data) {
+  return Object.entries(data).map(([key, value]) => (
+    {
+      name: key,
+      id: value.id,
+    }
+  ));
+}
+
 function normalizePluginConfig(data) {
   if (!data || Object.keys(data).length < 1) {
     return {};
@@ -33,12 +42,6 @@ function normalizePluginConfig(data) {
     // what the topic title is for the second.  "Questions for TAs" maybe?
     divideGeneralTopic: false,
     divideQuestionsForTAsTopic: false,
-    discussionTopics: Object.entries(data.discussion_topics).map(([key, value]) => (
-      {
-        name: key,
-        id: value.id,
-      }
-    )),
   };
 }
 
@@ -63,6 +66,11 @@ function normalizeApps(data) {
     },
     activeAppId: data.providers.active,
     apps,
+    discussionTopicIds: Object.entries(
+      data.plugin_configuration.discussion_topics,
+    // eslint-disable-next-line no-unused-vars
+    ).map(([key, value]) => value.id),
+    discussionTopics: normalizeDiscussionTopic(data.plugin_configuration.discussion_topics),
   };
 }
 

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -33,6 +33,12 @@ function normalizePluginConfig(data) {
     // what the topic title is for the second.  "Questions for TAs" maybe?
     divideGeneralTopic: false,
     divideQuestionsForTAsTopic: false,
+    discussionTopics: Object.entries(data.discussion_topics).map(([key, value]) => (
+      {
+        name: key,
+        id: value.id,
+      }
+    )),
   };
 }
 
@@ -80,6 +86,13 @@ function denormalizeData(courseId, appId, data) {
   }
   if (data.blackoutDates) {
     pluginConfiguration.discussion_blackouts = JSON.parse(data.blackoutDates);
+  }
+  if (data.discussionTopics.length) {
+    pluginConfiguration.discussion_topics = data.discussionTopics.reduce((topics, currentTopic) => {
+      const newTopics = { ...topics };
+      newTopics[currentTopic.name] = { id: currentTopic.id };
+      return newTopics;
+    }, {});
   }
 
   const ltiConfiguration = {};

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -132,6 +132,7 @@ describe('Data layer integration tests', () => {
         status: LOADED,
         saveStatus: SAVED,
         hasValidationError: false,
+        discussionTopicIds: [],
       });
       expect(store.getState().models.apps.legacy).toEqual(legacyApp);
       expect(store.getState().models.apps.piazza).toEqual(piazzaApp);
@@ -157,6 +158,10 @@ describe('Data layer integration tests', () => {
         status: LOADED,
         saveStatus: SAVED,
         hasValidationError: false,
+        discussionTopicIds: [
+          '13f106c6-6735-4e84-b097-0456cff55960',
+          'course-generated-id-123-client-made-this-up',
+        ],
       });
       expect(store.getState().models.apps.legacy).toEqual(legacyApp);
       expect(store.getState().models.apps.piazza).toEqual(piazzaApp);

--- a/src/pages-and-resources/discussions/data/slice.js
+++ b/src/pages-and-resources/discussions/data/slice.js
@@ -23,6 +23,7 @@ const slice = createSlice({
     saveStatus: SAVED,
     // ValidationError is the Flag that represents a form validation status.
     hasValidationError: false,
+    discussionTopicIds: [],
   },
   reducers: {
     loadApps: (state, { payload }) => {
@@ -31,6 +32,7 @@ const slice = createSlice({
       state.featureIds = payload.featureIds;
       state.status = LOADED;
       state.saveStatus = SAVED;
+      state.discussionTopicIds = payload.discussionTopicIds;
     },
     selectApp: (state, { payload }) => {
       const { appId } = payload;
@@ -48,6 +50,9 @@ const slice = createSlice({
       const { hasError } = payload;
       state.hasValidationError = hasError;
     },
+    updateDiscussionTopicIds: (state, { payload }) => {
+      state.discussionTopicIds = payload;
+    },
   },
 });
 
@@ -57,6 +62,7 @@ export const {
   updateStatus,
   updateSaveStatus,
   updateValidationStatus,
+  updateDiscussionTopicIds,
 } = slice.actions;
 
 export const {

--- a/src/pages-and-resources/discussions/data/thunks.js
+++ b/src/pages-and-resources/discussions/data/thunks.js
@@ -1,5 +1,7 @@
 import { history } from '@edx/frontend-platform';
-import { addModel, addModels } from '../../../generic/model-store';
+import {
+  addModel, addModels, updateModel, updateModels,
+} from '../../../generic/model-store';
 
 import { getApps, postAppConfig } from './api';
 import {
@@ -22,15 +24,20 @@ export function fetchApps(courseId) {
         features,
         activeAppId,
         appConfig,
+        discussionTopicIds,
+        discussionTopics,
       } = await getApps(courseId);
 
       dispatch(addModels({ modelType: 'apps', models: apps }));
       dispatch(addModels({ modelType: 'features', models: features }));
       dispatch(addModel({ modelType: 'appConfigs', model: appConfig }));
+      dispatch(addModels({ modelType: 'discussionTopics', models: discussionTopics }));
+
       dispatch(loadApps({
         activeAppId,
         appIds: apps.map(app => app.id),
         featureIds: features.map(feature => feature.id),
+        discussionTopicIds,
       }));
     } catch (error) {
       if (error.response && error.response.status === 403) {
@@ -52,15 +59,20 @@ export function saveAppConfig(courseId, appId, drafts, successPath) {
         features,
         activeAppId,
         appConfig,
+        discussionTopicIds,
+        discussionTopics,
       } = await postAppConfig(courseId, appId, drafts);
 
       dispatch(addModels({ modelType: 'apps', models: apps }));
       dispatch(addModels({ modelType: 'features', models: features }));
       dispatch(addModel({ modelType: 'appConfigs', model: appConfig }));
+      dispatch(addModels({ modelType: 'discussionTopics', models: discussionTopics }));
+
       dispatch(loadApps({
         activeAppId,
         appIds: apps.map(app => app.id),
         featureIds: features.map(feature => feature.id),
+        discussionTopicIds,
       }));
       dispatch(updateSaveStatus({ status: SAVED }));
       // Note that we redirect here to avoid having to work with the promise over in AppConfigForm.
@@ -74,5 +86,14 @@ export function saveAppConfig(courseId, appId, drafts, successPath) {
         dispatch(updateSaveStatus({ status: FAILED }));
       }
     }
+  };
+}
+
+export function updatedDiscussionTopics(payload) {
+  return (dispatch) => {
+    const { discussionTopics, ...appConfig } = payload;
+
+    dispatch(updateModel({ modelType: 'appConfigs', model: appConfig }));
+    dispatch(updateModels({ modelType: 'discussionTopics', models: discussionTopics }));
   };
 }

--- a/src/pages-and-resources/discussions/data/thunks.js
+++ b/src/pages-and-resources/discussions/data/thunks.js
@@ -1,6 +1,6 @@
 import { history } from '@edx/frontend-platform';
 import {
-  addModel, addModels, updateModel, updateModels,
+  addModel, addModels, updateModels,
 } from '../../../generic/model-store';
 
 import { getApps, postAppConfig } from './api';
@@ -91,9 +91,6 @@ export function saveAppConfig(courseId, appId, drafts, successPath) {
 
 export function updatedDiscussionTopics(payload) {
   return (dispatch) => {
-    const { discussionTopics, ...appConfig } = payload;
-
-    dispatch(updateModel({ modelType: 'appConfigs', model: appConfig }));
-    dispatch(updateModels({ modelType: 'discussionTopics', models: discussionTopics }));
+    dispatch(updateModels({ modelType: 'discussionTopics', models: payload }));
   };
 }

--- a/src/pages-and-resources/discussions/data/thunks.js
+++ b/src/pages-and-resources/discussions/data/thunks.js
@@ -90,7 +90,7 @@ export function saveAppConfig(courseId, appId, drafts, successPath) {
 }
 
 export function updatedDiscussionTopics(payload) {
-  return (dispatch) => {
+  return async (dispatch) => {
     dispatch(updateModels({ modelType: 'discussionTopics', models: payload }));
   };
 }

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -48,6 +48,15 @@ export const legacyApiResponse = {
   plugin_configuration: {
     allow_anonymous: false,
     allow_anonymous_to_peers: false,
+    always_divide_inline_discussions: false,
+    available_division_schemes: ['enrollment_track'],
+    discussion_topics: {
+      Edx: { id: '13f106c6-6735-4e84-b097-0456cff55960' },
+      General: { id: 'course-generated-id-123-client-made-this-up' },
+    },
+    divided_course_wide_discussions: [],
+    divided_inline_discussions: [],
+    division_scheme: 'none',
     // Note, this gets stringified when normalized into the app, but the API returns it as an
     // actual array.  Argh.
     discussion_blackouts: [],


### PR DESCRIPTION
- Add UI for General discussion topics
- Modify formik form for handing the topic field 
- normalize discussion_topics response into formik required format
- de-normalise discussion_topics payload for post request
- Manage discussion_topics data in redux modal
- Store all discussionTopicsIds in discussion reducer

**Updated UI design screenshots:** 
<img width="858" alt="Screenshot 2021-05-11 at 11 48 55 PM" src="https://user-images.githubusercontent.com/79941147/117869030-baee4680-b2b3-11eb-8e8d-b4f64676bc17.png">
<img width="845" alt="Screenshot 2021-05-11 at 11 49 30 PM" src="https://user-images.githubusercontent.com/79941147/117869046-be81cd80-b2b3-11eb-9b13-b2c33c466dc9.png">
<img width="800" alt="Screenshot 2021-05-18 at 7 10 16 PM" src="https://user-images.githubusercontent.com/79941147/118666621-c3430600-b80c-11eb-88ba-ba3f1e80a8df.png">
<img width="937" alt="Screenshot 2021-05-11 at 11 50 17 PM" src="https://user-images.githubusercontent.com/79941147/117869053-c04b9100-b2b3-11eb-8037-e0ff7d64c4a8.png">
<img width="800" alt="Screenshot 2021-05-11 at 11 50 30 PM" src="https://user-images.githubusercontent.com/79941147/117869058-c0e42780-b2b3-11eb-91eb-44592cafb9e7.png">
