### PR TITLE
fix: update discussions API handler to match shape from server

### DIFF
--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -37,12 +37,12 @@ function normalizePluginConfig(data) {
 }
 
 function normalizeApps(data) {
-  const apps = Object.entries(data.providers.available).map(([key, app]) => ({
+  const apps = Object.entries(data.providers.available).map(([key, appFeatures]) => ({
     id: key,
-    featureIds: app.features,
+    featureIds: appFeatures,
     // TODO: Fix this and get it from the backend!
     documentationUrl: 'http://example.com',
-    hasFullSupport: app.features.length >= data.features.length,
+    hasFullSupport: appFeatures.length >= data.features.length,
   }));
   return {
     courseId: data.context_key,

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -18,22 +18,18 @@ export const piazzaApiResponse = {
   providers: {
     active: 'piazza',
     available: {
-      legacy: {
-        features: [
-          'discussion-page',
-          'embedded-course-sections',
-          'wcag-2.1',
-        ],
-      },
-      piazza: {
-        features: [
-          // We give piazza all features just so we can test our "full support" text.
-          'discussion-page',
-          'embedded-course-sections',
-          'wcag-2.1',
-          'lti',
-        ],
-      },
+      legacy: [
+        'discussion-page',
+        'embedded-course-sections',
+        'wcag-2.1',
+      ],
+      piazza: [
+        // We give piazza all features just so we can test our "full support" text.
+        'discussion-page',
+        'embedded-course-sections',
+        'wcag-2.1',
+        'lti',
+      ],
     },
   },
 };
@@ -59,22 +55,18 @@ export const legacyApiResponse = {
   providers: {
     active: 'legacy',
     available: {
-      legacy: {
-        features: [
-          'discussion-page',
-          'embedded-course-sections',
-          'wcag-2.1',
-        ],
-      },
-      piazza: {
-        features: [
-          // We give piazza all features just so we can test our "full support" text.
-          'discussion-page',
-          'embedded-course-sections',
-          'wcag-2.1',
-          'lti',
-        ],
-      },
+      legacy: [
+        'discussion-page',
+        'embedded-course-sections',
+        'wcag-2.1',
+      ],
+      piazza: [
+        // We give piazza all features just so we can test our "full support" text.
+        'discussion-page',
+        'embedded-course-sections',
+        'wcag-2.1',
+        'lti',
+      ],
     },
   },
 };


### PR DESCRIPTION
The application was expecting a different API shape than the server was sending.  I have _no_ idea how this made it through, as it’s blatantly broken.  I don’t see any changes in this code in the past few weeks.

Anyway, the client was expecting a “features” array inside an app (provider), which simply didn’t exist.  The app itself is the array.  This PR udpates the shape in `normalizeApps` and also the associated test, which was also equally as wrong.  Somehow.