### PR TITLE
Fixed padding in discussion settings modal

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.jsx
@@ -86,7 +86,7 @@ function DiscussionsSettings({ courseId, intl }) {
         <Stepper activeKey={currentStep}>
           <FullscreenModal
             className="bg-light-200"
-            modalBodyClassName="p-0"
+            modalBodyClassName="px-sm-4 p-0"
             title={intl.formatMessage(messages.configure)}
             onClose={handleClose}
             isOpen


### PR DESCRIPTION
## Before : 

<img width="1440" alt="Screenshot 2021-05-04 at 3 09 05 PM" src="https://user-images.githubusercontent.com/26253150/116989110-bf7e9200-acea-11eb-9378-df36c25661c7.png">

## After : 
<img width="1440" alt="Screenshot 2021-05-04 at 3 08 34 PM" src="https://user-images.githubusercontent.com/26253150/116989126-c4434600-acea-11eb-99b7-05488956b960.png">
