### PR TITLE
chore: bump paragon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3468,9 +3468,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.11.0.tgz",
-      "integrity": "sha512-k7CrjoTPiQ1bF/Dp8GI5OGezvporODtYYEwZYP5otTGEfuu/y8kMBUekVX6dJI8oX2Ohm7AeEjSTfiNCrPoncA==",
+      "version": "14.11.2",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.11.2.tgz",
+      "integrity": "sha512-2DBC1/3PUwZ7hcGRjT0dGVC5C66TL0Tx/yBEEbjRtQ8BDfiubGizE7wlUYC9VCWhVQgCOwpU5VRHztvp+XRX8A==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.0.11",
     "@edx/frontend-platform": "1.9.0",
-    "@edx/paragon": "14.11.0",
+    "@edx/paragon": "14.11.2",
     "@fortawesome/fontawesome-svg-core": "1.2.28",
     "@fortawesome/free-brands-svg-icons": "5.11.2",
     "@fortawesome/free-regular-svg-icons": "5.11.2",


### PR DESCRIPTION
Bump paragon to 14.11.2

This fixes the following
* update `statefulbutton` icons
* update Proptypes to avoid errors