### PR TITLE
refactor: update full screen modal

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.jsx
@@ -104,7 +104,7 @@ function DiscussionsSettings({ courseId, intl }) {
                     >
                       {intl.formatMessage(messages.backButton)}
                     </Button>
-                    <AppConfigForm.ApplyButton />
+                    <AppConfigForm.SaveButton />
                   </div>
                 </Stepper.ActionRow>
               </>

--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -25,9 +25,10 @@ import PagesAndResourcesProvider from '../PagesAndResourcesProvider';
 import initializeStore from '../../store';
 import { getAppsUrl } from './data/api';
 import { piazzaApiResponse } from './factories/mockApiResponses';
+import appMessages from './app-config-form/messages';
+import appListMessages from './app-list/messages';
 
 const courseId = 'course-v1:edX+TestX+Test_Course';
-
 let axiosMock;
 let store;
 let container;
@@ -107,7 +108,7 @@ describe('DiscussionsSettings', () => {
       await waitForElementToBeRemoved(screen.getByRole('status'));
 
       userEvent.click(queryByLabelText(container, 'Select Piazza'));
-      userEvent.click(queryByText(container, 'Next'));
+      userEvent.click(queryByText(container, appListMessages.nextButton.defaultMessage));
 
       expect(queryByTestId(container, 'appList')).not.toBeInTheDocument();
       expect(queryByTestId(container, 'appConfigForm')).toBeInTheDocument();
@@ -123,7 +124,7 @@ describe('DiscussionsSettings', () => {
       await waitForElementToBeRemoved(screen.getByRole('status'));
 
       userEvent.click(queryByLabelText(container, 'Select edX Discussions'));
-      userEvent.click(queryByText(container, 'Next'));
+      userEvent.click(queryByText(container, appListMessages.nextButton.defaultMessage));
 
       expect(queryByTestId(container, 'appList')).not.toBeInTheDocument();
       expect(queryByTestId(container, 'appConfigForm')).toBeInTheDocument();
@@ -140,7 +141,7 @@ describe('DiscussionsSettings', () => {
 
       expect(queryByTestId(container, 'appConfigForm')).toBeInTheDocument();
 
-      userEvent.click(queryByText(container, 'Back'));
+      userEvent.click(queryByText(container, appMessages.backButton.defaultMessage));
 
       expect(queryByTestId(container, 'appList')).toBeInTheDocument();
       expect(queryByTestId(container, 'appConfigForm')).not.toBeInTheDocument();
@@ -173,10 +174,10 @@ describe('DiscussionsSettings', () => {
       await waitForElementToBeRemoved(screen.getByRole('status'));
 
       userEvent.click(queryByLabelText(container, 'Select Piazza'));
-      userEvent.click(queryByText(container, 'Next'));
+      userEvent.click(queryByText(container, appListMessages.nextButton.defaultMessage));
       // Apply causes an async action to take place
       act(() => {
-        userEvent.click(queryByText(container, 'Apply'));
+        userEvent.click(queryByText(container, appMessages.saveButton.defaultMessage));
       });
 
       // This is an important line that ensures the Close button has been removed, which implies that
@@ -237,7 +238,7 @@ describe('DiscussionsSettings', () => {
 
       // Apply causes an async action to take place
       act(() => {
-        userEvent.click(queryByText(container, 'Apply'));
+        userEvent.click(queryByText(container, appMessages.saveButton.defaultMessage));
       });
 
       await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
@@ -288,7 +289,7 @@ describe('DiscussionsSettings', () => {
 
       // Apply causes an async action to take place
       act(() => {
-        userEvent.click(queryByText(container, 'Apply'));
+        userEvent.click(queryByText(container, appMessages.saveButton.defaultMessage));
       });
 
       await waitFor(() => expect(axiosMock.history.post.length).toBe(1));

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigForm.jsx
@@ -16,7 +16,7 @@ import { saveAppConfig } from '../data/thunks';
 
 import messages from './messages';
 import AppConfigFormProvider, { AppConfigFormContext } from './AppConfigFormProvider';
-import AppConfigFormApplyButton from './AppConfigFormApplyButton';
+import AppConfigFormSaveButton from './AppConfigFormSaveButton';
 import LegacyConfigForm from './apps/legacy';
 import LtiConfigForm from './apps/lti';
 import Loading from '../../../generic/Loading';
@@ -100,6 +100,6 @@ AppConfigForm.propTypes = {
 const IntlAppConfigForm = injectIntl(AppConfigForm);
 
 IntlAppConfigForm.Provider = AppConfigFormProvider;
-IntlAppConfigForm.ApplyButton = AppConfigFormApplyButton;
+IntlAppConfigForm.SaveButton = AppConfigFormSaveButton;
 
 export default IntlAppConfigForm;

--- a/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/AppConfigFormSaveButton.jsx
@@ -7,33 +7,33 @@ import messages from './messages';
 import { SAVING } from '../data/slice';
 import { AppConfigFormContext } from './AppConfigFormProvider';
 
-function AppConfigFormApplyButton({ intl }) {
+function AppConfigFormSaveButton({ intl }) {
   const saveStatus = useSelector(state => state.discussions.saveStatus);
   const { formRef } = useContext(AppConfigFormContext);
 
   const submitButtonState = saveStatus === SAVING ? 'pending' : 'default';
 
   // This causes the form to be submitted from a button outside the form.
-  const handleApply = useCallback(() => {
+  const handleSave = useCallback(() => {
     formRef.current.requestSubmit();
   }, [formRef]);
 
   return (
     <StatefulButton
       labels={{
-        default: intl.formatMessage(messages.applyButton),
-        pending: intl.formatMessage(messages.applyingButton),
-        complete: intl.formatMessage(messages.appliedButton),
+        default: intl.formatMessage(messages.saveButton),
+        pending: intl.formatMessage(messages.savingButton),
+        complete: intl.formatMessage(messages.savedButton),
       }}
       state={submitButtonState}
       className="mr-2"
-      onClick={handleApply}
+      onClick={handleSave}
     />
   );
 }
 
-AppConfigFormApplyButton.propTypes = {
+AppConfigFormSaveButton.propTypes = {
   intl: intlShape.isRequired,
 };
 
-export default injectIntl(AppConfigFormApplyButton);
+export default injectIntl(AppConfigFormSaveButton);

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -14,19 +14,19 @@ const messages = defineMessages({
     defaultMessage: 'Back',
     description: 'Button allowing the user to return to discussion app selection.',
   },
-  applyButton: {
-    id: 'authoring.discussions.applyButton',
-    defaultMessage: 'Apply',
+  saveButton: {
+    id: 'authoring.discussions.saveButton',
+    defaultMessage: 'Save',
     description: 'Button allowing the user to submit their discussion configuration.',
   },
-  applyingButton: {
-    id: 'authoring.discussions.applyingButton',
-    defaultMessage: 'Applying',
+  savingButton: {
+    id: 'authoring.discussions.savingButton',
+    defaultMessage: 'Saving',
     description: 'Button label when the discussion configuration is being submitted.',
   },
-  appliedButton: {
-    id: 'authoring.discussions.appliedButton',
-    defaultMessage: 'Applied',
+  savedButton: {
+    id: 'authoring.discussions.savedButton',
+    defaultMessage: 'Saved',
     description: 'Button label when the discussion configuration has been successfully submitted.',
   },
 


### PR DESCRIPTION
This PR adds the following changes.
* Fixes a bug in `satefullbutton`
* Updates labels of `fullscreenmodal`

**Next**
<img width="463" alt="Screen Shot 2021-05-18 at 1 28 46 PM" src="https://user-images.githubusercontent.com/4252738/118618426-0c7b6180-b7dd-11eb-90e6-ebf210c08ffe.png">

**Save**

<img width="338" alt="Screen Shot 2021-05-18 at 1 28 58 PM" src="https://user-images.githubusercontent.com/4252738/118618398-038a9000-b7dd-11eb-9d4e-2b687e714072.png">

**Saving**
<img width="216" alt="Screen Shot 2021-05-18 at 1 29 07 PM" src="https://user-images.githubusercontent.com/4252738/118618413-07b6ad80-b7dd-11eb-9d3c-a6b5845596fe.png">


https://openedx.atlassian.net/browse/TNL-8320
