### PR TITLE
style: added icon buttons for fixing hover styling for topic actions

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Collapsible, Form, Card, Button,
+  Collapsible, Form, Card, Button, IconButton, Icon,
 } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import { useFormikContext } from 'formik';
@@ -102,17 +102,33 @@ const TopicItem = ({
             >
               <Collapsible.Visible whenClosed>
                 {getHeading(false)}
-                <div className="py-2 ml-auto">
-                  <ExpandMore />
+                <div className="ml-auto">
+                  <IconButton
+                    alt={intl.formatMessage(messages.expandAltText)}
+                    src={ExpandMore}
+                    iconAs={Icon}
+                    variant="dark"
+                  />
                 </div>
               </Collapsible.Visible>
               <Collapsible.Visible whenOpen>
                 {getHeading(true)}
                 <div className="pr-4 border-right">
-                  <Delete onClick={deleteDiscussionTopic} />
+                  <IconButton
+                    onClick={deleteDiscussionTopic}
+                    alt={intl.formatMessage(messages.deleteAltText)}
+                    src={Delete}
+                    iconAs={Icon}
+                    variant="dark"
+                  />
                 </div>
                 <div className="pl-4">
-                  <ExpandLess />
+                  <IconButton
+                    alt={intl.formatMessage(messages.collapseAltText)}
+                    src={ExpandLess}
+                    iconAs={Icon}
+                    variant="dark"
+                  />
                 </div>
               </Collapsible.Visible>
             </Collapsible.Trigger>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
@@ -171,6 +171,18 @@ const messages = defineMessages({
     id: 'authoring.discussions.builtIn.blackoutDates.formattingError',
     defaultMessage: "There's a formatting error in your blackout dates.",
   },
+  deleteAltText: {
+    id: 'authoring.topics.delete',
+    defaultMessage: 'Delete Topic',
+  },
+  expandAltText: {
+    id: 'authoring.topics.expand',
+    defaultMessage: 'Expand',
+  },
+  collapseAltText: {
+    id: 'authoring.topics.collapse',
+    defaultMessage: 'Collapse',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
Replaced icon with button icon for the following actions in topics
1. expand
2. collapse
3. delete

<img width="1434" alt="Screenshot 2021-05-28 at 4 11 14 PM" src="https://user-images.githubusercontent.com/67791278/119975513-6515e000-bfcf-11eb-8443-85e661d43261.png">
<img width="1435" alt="Screenshot 2021-05-31 at 4 24 15 PM" src="https://user-images.githubusercontent.com/67791278/120186616-2a10e800-c22d-11eb-8cf9-e3b5970af7a9.png">
<img width="1445" alt="Screenshot 2021-05-31 at 4 24 00 PM" src="https://user-images.githubusercontent.com/67791278/120186645-32692300-c22d-11eb-8e94-7df239e76d0c.png">


Figma guidelines about using icon button is attached.
<img width="1433" alt="Screenshot 2021-05-31 at 5 36 15 PM" src="https://user-images.githubusercontent.com/67791278/120194467-136f8e80-c237-11eb-8dcc-2a6372616dfc.png">

