### PR TITLE
feat: add collapsible card validation for empty field

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/DivisionByGroupFields.jsx
@@ -116,13 +116,15 @@ function DivisionByGroupFields({
                           defaultValue={divideDiscussionIds}
                         >
                           {discussionTopics.map((topic) => (
-                            <Form.Checkbox
-                              key={`checkbox-${topic.id}`}
-                              id={`checkbox-${topic.id}`}
-                              value={topic.id}
-                            >
-                              {topic.name}
-                            </Form.Checkbox>
+                            topic.name ? (
+                              <Form.Checkbox
+                                key={`checkbox-${topic.id}`}
+                                id={`checkbox-${topic.id}`}
+                                value={topic.id}
+                              >
+                                {topic.name}
+                              </Form.Checkbox>
+                            ) : null
                           ))}
                         </Form.CheckboxSet>
                       </Form.Group>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/DiscussionTopics.jsx
@@ -67,12 +67,11 @@ const DiscussionTopics = ({ intl }) => {
                 ))
               }
               <div className="mb-4">
-                <Add />
                 <Button
                   onClick={() => addNewTopic(push)}
                   variant="link"
-                  size="inline"
-                  className="mr-1 text-primary-500"
+                  iconBefore={Add}
+                  className="text-primary-500 p-0"
                 >
                   {intl.formatMessage(messages.addTopicButton)}
                 </Button>

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -17,6 +17,8 @@ const TopicItem = ({
 }) => {
   const [title, setTitle] = useState(name);
   const [showDeletePopup, setShowDeletePopup] = useState(false);
+  const [collapseIsOpen, setCollapseOpen] = useState(!name.length);
+
   const {
     handleChange,
     handleBlur,
@@ -49,7 +51,12 @@ const TopicItem = ({
   const getHeading = (isOpen = false) => {
     let heading;
     if (isGeneralTopic && isOpen) {
-      heading = <span className="h4 py-2 mr-auto">{intl.formatMessage(messages.renameGeneralTopic)}</span>;
+      heading = (
+        <div className="h4 py-2 mr-auto">
+          {intl.formatMessage(messages.renameGeneralTopic)}
+          <div className="small text-muted mt-2">{intl.formatMessage(messages.generalTopicHelp)}</div>
+        </div>
+      );
     } else if (isOpen) {
       heading = <span className="h4 py-2 mr-auto">{intl.formatMessage(messages.configureAdditionalTopic)}</span>;
     } else {
@@ -58,10 +65,27 @@ const TopicItem = ({
     return heading;
   };
 
-  const handleToggle = (isOpen) => {
-    if (!isOpen && !isInvalidTopicNameKey) {
+  const collapseCardValidation = (isOpen) => {
+    const inputIsUnTouch = isOpen || !title.length;
+    const inputHasError = !isOpen && (!title.length || isExistingName);
+
+    if (inputHasError || inputIsUnTouch) {
+      setCollapseOpen(true);
+    } else {
+      setCollapseOpen(false);
+    }
+  };
+
+  const updateTitle = (isOpen) => {
+    const inputHasError = !isOpen && !isInvalidTopicNameKey && !isExistingName;
+    if (inputHasError) {
       setTitle(name);
     }
+  };
+
+  const handleToggle = (isOpen) => {
+    collapseCardValidation(isOpen);
+    updateTitle(isOpen);
   };
 
   const deleteDiscussionTopic = (event) => {
@@ -107,6 +131,7 @@ const TopicItem = ({
             className="collapsible-card rounded mb-3 px-3 py-2"
             onToggle={handleToggle}
             defaultOpen={!title}
+            open={collapseIsOpen}
             id={id}
           >
             <Collapsible.Trigger

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -65,27 +65,13 @@ const TopicItem = ({
     return heading;
   };
 
-  const collapseCardValidation = (isOpen) => {
-    const inputIsUnTouch = isOpen || !title.length;
-    const inputHasError = !isOpen && (!title.length || isExistingName);
-
-    if (inputHasError || inputIsUnTouch) {
-      setCollapseIsOpen(true);
-    } else {
-      setCollapseIsOpen(false);
-    }
-  };
-
-  const updateTitle = (isOpen) => {
-    const inputHasError = !isOpen && !isInvalidTopicNameKey && !isExistingName;
-    if (inputHasError) {
-      setTitle(name);
-    }
-  };
-
   const handleToggle = (isOpen) => {
-    collapseCardValidation(isOpen);
-    updateTitle(isOpen);
+    if (!isOpen) {
+      const inputHasError = !name.length || isExistingName || isInvalidTopicNameKey;
+      setCollapseIsOpen(inputHasError);
+    } else {
+      setCollapseIsOpen(isOpen);
+    }
   };
 
   const deleteDiscussionTopic = (event) => {

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/discussion-topics/TopicItem.jsx
@@ -17,7 +17,7 @@ const TopicItem = ({
 }) => {
   const [title, setTitle] = useState(name);
   const [showDeletePopup, setShowDeletePopup] = useState(false);
-  const [collapseIsOpen, setCollapseOpen] = useState(!name.length);
+  const [collapseIsOpen, setCollapseIsOpen] = useState(!name.length);
 
   const {
     handleChange,
@@ -70,9 +70,9 @@ const TopicItem = ({
     const inputHasError = !isOpen && (!title.length || isExistingName);
 
     if (inputHasError || inputIsUnTouch) {
-      setCollapseOpen(true);
+      setCollapseIsOpen(true);
     } else {
-      setCollapseOpen(false);
+      setCollapseIsOpen(false);
     }
   };
 

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/messages.js
@@ -152,6 +152,11 @@ const messages = defineMessages({
     defaultMessage: 'Rename general topic',
     description: 'Label for default topic allowing user to rename default general topic',
   },
+  generalTopicHelp: {
+    id: 'authoring.discussions.generalTopicHelp.help',
+    defaultMessage: 'This is the default discussion topic for your course.',
+    description: 'Help text for general discussion topic collapsible card.',
+  },
   configureAdditionalTopic: {
     id: 'authoring.discussions.builtIn.configureAdditionalTopic.label',
     defaultMessage: 'Configure topic',


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-8257
1- If the discussion topic input field has a duplicate name or an empty input field error. It will not collapse the discussion topic card.
2- Empty input field discussion topic name will not be available in divideByCohorts section.
3- General discussion topic has help text.
4- Add topic button has interactive Plus icon 

<img width="424" alt="Screenshot 2021-06-11 at 7 21 44 PM" src="https://user-images.githubusercontent.com/79941147/121702624-7c82bc00-caeb-11eb-982c-bded6007879a.png">
