### PR TITLE
fix: LTI config form UI Fixes in App providers titles and external links.

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -8,7 +8,6 @@ import { useFormik } from 'formik';
 import * as Yup from 'yup';
 import { useDispatch } from 'react-redux';
 
-import AppConfigFormDivider from '../shared/AppConfigFormDivider';
 import AppExternalLinks from '../shared/AppExternalLinks';
 
 import {
@@ -91,7 +90,6 @@ function LtiConfigForm({
           )}
         </Form.Group>
       </Form>
-      <AppConfigFormDivider thick />
       <AppExternalLinks externalLinks={externalLinks} title={title} />
     </Card>
   );

--- a/src/pages-and-resources/discussions/app-config-form/apps/shared/AppExternalLinks.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/shared/AppExternalLinks.jsx
@@ -5,6 +5,8 @@ import {
   Hyperlink, MailtoLink,
 } from '@edx/paragon';
 
+import AppConfigFormDivider from './AppConfigFormDivider';
+
 import messages from '../lti/messages';
 
 function AppExternalLinks({
@@ -13,26 +15,30 @@ function AppExternalLinks({
   title,
 }) {
   const { contactEmail, ...links } = externalLinks;
-  const linkTypes = Object.keys(links);
+  const linkTypes = Object.keys(links).filter(key => links[key]);
   return (
     <div className="pt-4">
-      <h4>{intl.formatMessage(messages.linkTextHeading)}</h4>
-      <div className="small text-muted">
-        {linkTypes.map((type) => (
-          links[type] && (
-            <div key={type}>
-              <Hyperlink
-                destination={externalLinks[type]}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {intl.formatMessage(messages[type], { title })}
-              </Hyperlink>
-            </div>
-          )
-        ))}
-        <hr />
-        {contactEmail && (
+      {linkTypes.length
+        ? (
+          <>
+            <AppConfigFormDivider thick />
+            <h4 className="pt-4">{intl.formatMessage(messages.linkTextHeading)}</h4>
+            {linkTypes.map((type) => (
+              <div key={type} className="small text-muted">
+                <Hyperlink
+                  destination={externalLinks[type]}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  { intl.formatMessage(messages[type], { title }) }
+                </Hyperlink>
+              </div>
+            ))}
+          </>
+        ) : null}
+      {contactEmail && (
+        <div className="small text-muted">
+          <hr />
           <FormattedMessage
             {...messages.contact}
             values={{
@@ -41,13 +47,13 @@ function AppExternalLinks({
                   to={contactEmail}
                   rel="noopener noreferrer"
                 >
-                  {contactEmail}
+                  { contactEmail }
                 </MailtoLink>
               ),
             }}
           />
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages-and-resources/discussions/app-config-form/messages.js
+++ b/src/pages-and-resources/discussions/app-config-form/messages.js
@@ -36,6 +36,31 @@ const messages = defineMessages({
     defaultMessage: 'Piazza',
     description: 'The name of the Piazza app.',
   },
+  'appName-edx-next': {
+    id: 'authoring.discussions.appConfigForm.appName-edx-next',
+    defaultMessage: 'EdX Next',
+    description: 'The name of the EdX Next app.',
+  },
+  'appName-yellowdig': {
+    id: 'authoring.discussions.appConfigForm.appName-yellowdig',
+    defaultMessage: 'Yellowdig',
+    description: 'The name of the yellowdig app.',
+  },
+  'appName-inscribe': {
+    id: 'authoring.discussions.appConfigForm.appName-inscribe',
+    defaultMessage: 'Inscribe',
+    description: 'The name of the inscribe app.',
+  },
+  'appName-discourse': {
+    id: 'authoring.discussions.appConfigForm.appName-discourse',
+    defaultMessage: 'Discourse',
+    description: 'The name of the discourse app.',
+  },
+  'appName-ed-discuss': {
+    id: 'authoring.discussions.appConfigForm.appName-ed-discuss',
+    defaultMessage: 'Ed Discuss',
+    description: 'The name of the Ed Discuss app.',
+  },
   'appName-legacy': {
     id: 'authoring.discussions.appConfigForm.appName-legacy',
     defaultMessage: 'edX Discussions',


### PR DESCRIPTION
LTI config form title fixed for app providers and eternal link heading fixes for app provider which don't have any external link/contact email.

Ticket: Ticket: https://openedx.atlassian.net/browse/TNL-8401
Parent Ticket: https://openedx.atlassian.net/browse/TNL-7832

1. external links were implemented for app providers but some app providers were missing any external link. which creates undesired UI headings to fix that this PR is generated so that the external links section will only be visible for that provider which has external documentation links/contact emails.
2. a console error started appearing on UI since new providers were added, due to missing app names in i18n messages structures. the missing title has also been added to remove the issue. 


