### PR TITLE
Update paragon to fix shadow under content issue 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3483,9 +3483,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "14.16.7",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.16.7.tgz",
-      "integrity": "sha512-wQr6fpKeNkfk3ZEA+VtEI0J8MGYCg/gQj9n7pYb7vRNzoQ1XYnnt2C23BszE+WPH4oJ/J8ROU3Z823yXAYUBuQ==",
+      "version": "14.16.9",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-14.16.9.tgz",
+      "integrity": "sha512-aqb7GKy7ty4TmETU4EhB72IssVxssvvSmWUpROKD0xsDV6gwgUXI1tSQ6myFijzNiUyotHNHYfxTEKozjZIhNw==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-footer": "10.0.11",
     "@edx/frontend-platform": "1.11.0",
-    "@edx/paragon": "14.16.7",
+    "@edx/paragon": "14.16.9",
     "@fortawesome/fontawesome-svg-core": "1.2.28",
     "@fortawesome/free-brands-svg-icons": "5.11.2",
     "@fortawesome/free-regular-svg-icons": "5.11.2",

--- a/src/pages-and-resources/discussions/DiscussionsSettings.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.jsx
@@ -86,7 +86,7 @@ function DiscussionsSettings({ courseId, intl }) {
         <Stepper activeKey={currentStep}>
           <FullscreenModal
             className="bg-light-200"
-            modalBodyClassName="px-sm-4 p-0"
+            modalBodyClassName="px-sm-4"
             title={intl.formatMessage(messages.configure)}
             onClose={handleClose}
             isOpen


### PR DESCRIPTION
In reference to this [ticket](https://openedx.atlassian.net/browse/TNL-8405) the shadow was appearing under the setting page content in the modal. to fix that update is made in paragon and course authoring MFE is bumped to the latest(14.16.9) paragon version and a class is removed which was creating an issue in the shadow position. 

The new screen is shown below. 

<img width="1194" alt="Screenshot 2021-06-23 at 11 07 38 PM" src="https://user-images.githubusercontent.com/67791278/123147003-f87bed00-d477-11eb-8733-b75f7e42f66f.png">
<img width="1201" alt="Screenshot 2021-06-23 at 11 08 07 PM" src="https://user-