### PR TITLE
feat: Adds settings pages for edxnotes, progress and wiki [BD-38] [TNL-8101] [TNL-8451] [TNL-8452] [TNL-8455]

### DIFF
--- a/src/pages-and-resources/data/api.js
+++ b/src/pages-and-resources/data/api.js
@@ -1,4 +1,6 @@
 /* eslint-disable import/prefer-default-export */
+import { snakeCase } from 'lodash/string';
+
 import { camelCaseObject, ensureConfig, getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
@@ -9,6 +11,7 @@ ensureConfig([
 const apiBaseUrl = getConfig().STUDIO_BASE_URL;
 
 const courseAppsApiUrl = `${apiBaseUrl}/api/course_apps/v1/apps`;
+const courseAdvancedSettingsApiUrl = `${apiBaseUrl}/api/contentstore/v0/advanced_settings`;
 
 /**
  * Fetches the course apps installed for provided course
@@ -36,4 +39,29 @@ export async function updateCourseApp(courseId, appId, state) {
         enabled: state,
       },
     );
+}
+
+/**
+ * Get's advanced setting for a course.
+ * @param {string} courseId
+ * @param {[string]} settings
+ * @returns {Promise<Object>}
+ */
+export async function getCourseAdvancedSettings(courseId, settings) {
+  const { data } = await getAuthenticatedHttpClient()
+    .get(`${courseAdvancedSettingsApiUrl}/${courseId}`, { filter_fields: settings.map(snakeCase).join(',') });
+  return camelCaseObject(data);
+}
+
+/**
+ * Get's advanced setting for a course.
+ * @param {string} courseId
+ * @param {string} setting
+ * @param {*} value
+ * @returns {Promise<Object>}
+ */
+export async function updateCourseAdvancedSettings(courseId, setting, value) {
+  const { data } = await getAuthenticatedHttpClient()
+    .patch(`${courseAdvancedSettingsApiUrl}/${courseId}`, { [snakeCase(setting)]: { value } });
+  return camelCaseObject(data);
 }

--- a/src/pages-and-resources/data/selectors.js
+++ b/src/pages-and-resources/data/selectors.js
@@ -1,5 +1,8 @@
 /* eslint-disable import/prefer-default-export */
 
-export const getLoadingStatus = (status) => status.pagesAndResources.loadingStatus;
-export const getSavingStatus = (status) => status.pagesAndResources.savingStatus;
-export const getCourseAppsApiStatus = (status) => status.pagesAndResources.courseAppsApiStatus;
+export const getLoadingStatus = (state) => state.pagesAndResources.loadingStatus;
+export const getSavingStatus = (state) => state.pagesAndResources.savingStatus;
+export const getCourseAppsApiStatus = (state) => state.pagesAndResources.courseAppsApiStatus;
+export const getCourseAppSettingValue = (setting) => (state) => (
+  state.pagesAndResources.courseAppSettings[setting]?.value
+);

--- a/src/pages-and-resources/data/slice.js
+++ b/src/pages-and-resources/data/slice.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from '@reduxjs/toolkit';
+
 import { RequestStatus } from '../../data/constants';
 
 const slice = createSlice({
@@ -9,6 +10,7 @@ const slice = createSlice({
     loadingStatus: RequestStatus.IN_PROGRESS,
     savingStatus: '',
     courseAppsApiStatus: {},
+    courseAppSettings: {},
   },
   reducers: {
     fetchCourseAppsSuccess: (state, { payload }) => {
@@ -23,6 +25,12 @@ const slice = createSlice({
     updateCourseAppsApiStatus: (state, { payload }) => {
       state.courseAppsApiStatus = payload.status;
     },
+    fetchCourseAppsSettingsSuccess: (state, { payload }) => {
+      Object.assign(state.courseAppSettings, payload);
+    },
+    updateCourseAppsSettingsSuccess: (state, { payload }) => {
+      Object.assign(state.courseAppSettings, payload);
+    },
   },
 });
 
@@ -31,6 +39,8 @@ export const {
   updateLoadingStatus,
   updateSavingStatus,
   updateCourseAppsApiStatus,
+  fetchCourseAppsSettingsSuccess,
+  updateCourseAppsSettingsSuccess,
 } = slice.actions;
 
 export const {

--- a/src/pages-and-resources/data/thunks.js
+++ b/src/pages-and-resources/data/thunks.js
@@ -1,14 +1,16 @@
 import { RequestStatus } from '../../data/constants';
-import {
-  getCourseApps,
-  updateCourseApp,
-} from './api';
 import { addModels, updateModel } from '../../generic/model-store';
 import {
+  getCourseAdvancedSettings,
+  getCourseApps, updateCourseAdvancedSettings,
+  updateCourseApp,
+} from './api';
+import {
+  fetchCourseAppsSettingsSuccess,
   fetchCourseAppsSuccess,
+  updateCourseAppsApiStatus, updateCourseAppsSettingsSuccess,
   updateLoadingStatus,
   updateSavingStatus,
-  updateCourseAppsApiStatus,
 } from './slice';
 
 const COURSE_APPS_ORDER = [
@@ -54,6 +56,34 @@ export function updateAppStatus(courseId, appId, state) {
     try {
       await updateCourseApp(courseId, appId, state);
       dispatch(updateModel({ modelType: 'courseApps', model: { id: appId, enabled: state } }));
+      dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
+    } catch (error) {
+      dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));
+    }
+  };
+}
+
+export function fetchCourseAppSettings(courseId, settings) {
+  return async (dispatch) => {
+    dispatch(updateLoadingStatus({ status: RequestStatus.IN_PROGRESS }));
+
+    try {
+      const settingValues = await getCourseAdvancedSettings(courseId, settings);
+      dispatch(fetchCourseAppsSettingsSuccess(settingValues));
+      dispatch(updateLoadingStatus({ status: RequestStatus.SUCCESSFUL }));
+    } catch (error) {
+      dispatch(updateLoadingStatus({ status: RequestStatus.FAILED }));
+    }
+  };
+}
+
+export function updateCourseAppSetting(courseId, setting, value) {
+  return async (dispatch) => {
+    dispatch(updateSavingStatus({ status: RequestStatus.IN_PROGRESS }));
+
+    try {
+      const settingValues = await updateCourseAdvancedSettings(courseId, setting, value);
+      dispatch(updateCourseAppsSettingsSuccess(settingValues));
       dispatch(updateSavingStatus({ status: RequestStatus.SUCCESSFUL }));
     } catch (error) {
       dispatch(updateSavingStatus({ status: RequestStatus.FAILED }));

--- a/src/pages-and-resources/edxnotes/Settings.jsx
+++ b/src/pages-and-resources/edxnotes/Settings.jsx
@@ -6,22 +6,22 @@ import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import AppSettingsModal from '../app-settings-modal/AppSettingsModal';
 import messages from './messages';
 
-function CalculatorSettings({ intl, onClose }) {
+function NotesSettings({ intl, onClose }) {
   return (
     <AppSettingsModal
-      appId="calculator"
+      appId="edxnotes"
       title={intl.formatMessage(messages.heading)}
-      enableAppHelp={intl.formatMessage(messages.enableCalculatorHelp)}
-      enableAppLabel={intl.formatMessage(messages.enableCalculatorLabel)}
-      learnMoreText={intl.formatMessage(messages.enableCalculatorLink)}
+      enableAppHelp={intl.formatMessage(messages.enableNotesHelp)}
+      enableAppLabel={intl.formatMessage(messages.enableNotesLabel)}
+      learnMoreText={intl.formatMessage(messages.enableNotesLink)}
       onClose={onClose}
     />
   );
 }
 
-CalculatorSettings.propTypes = {
+NotesSettings.propTypes = {
   intl: intlShape.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 
-export default injectIntl(CalculatorSettings);
+export default injectIntl(NotesSettings);

--- a/src/pages-and-resources/edxnotes/messages.js
+++ b/src/pages-and-resources/edxnotes/messages.js
@@ -1,0 +1,25 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  heading: {
+    id: 'course-authoring.pages-resources.notes.heading',
+    defaultMessage: 'Configure notes',
+  },
+  enableNotesLabel: {
+    id: 'course-authoring.pages-resources.notes.enable-notes.label',
+    defaultMessage: 'Notes',
+  },
+  enableNotesHelp: {
+    id: 'course-authoring.pages-resources.notes.enable-notes.help',
+    defaultMessage: `Learners can access their notes either in the body of the
+    course of on a notes page. On the notes page, a learner can see all the
+    notes made during the course. The page also contains links to the location
+    of the notes in the course body.`,
+  },
+  enableNotesLink: {
+    id: 'course-authoring.pages-resources.notes.enable-notes.link',
+    defaultMessage: 'Learn more about notes',
+  },
+});
+
+export default messages;

--- a/src/pages-and-resources/progress/Settings.jsx
+++ b/src/pages-and-resources/progress/Settings.jsx
@@ -1,0 +1,50 @@
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import PropTypes from 'prop-types';
+import React from 'react';
+import * as Yup from 'yup';
+
+import FormSwitchGroup from '../../generic/FormSwitchGroup';
+import { useAppSetting } from '../../utils';
+import AppSettingsModal from '../app-settings-modal/AppSettingsModal';
+import messages from './messages';
+
+function ProgressSettings({ intl, onClose }) {
+  const [disableProgressGraph, saveSetting] = useAppSetting('disableProgressGraph');
+
+  const handleSettingsSave = (values) => saveSetting(!values.enableProgressGraph);
+
+  return (
+    <AppSettingsModal
+      appId="progress"
+      title={intl.formatMessage(messages.heading)}
+      enableAppHelp={intl.formatMessage(messages.enableProgressHelp)}
+      enableAppLabel={intl.formatMessage(messages.enableProgressLabel)}
+      learnMoreText={intl.formatMessage(messages.enableProgressLink)}
+      onClose={onClose}
+      initialValues={{ enableProgressGraph: !disableProgressGraph }}
+      validationSchema={{ enableProgressGraph: Yup.boolean() }}
+      onSettingsSave={handleSettingsSave}
+    >
+      {
+        ({ handleChange, handleBlur, values }) => (
+          <FormSwitchGroup
+            id="enable-progress-graph"
+            name="enableProgressGraph"
+            label={intl.formatMessage(messages.enableGraphLabel)}
+            helpText={intl.formatMessage(messages.enableGraphHelp)}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            checked={values.enableProgressGraph}
+          />
+        )
+      }
+    </AppSettingsModal>
+  );
+}
+
+ProgressSettings.propTypes = {
+  intl: intlShape.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default injectIntl(ProgressSettings);

--- a/src/pages-and-resources/progress/messages.js
+++ b/src/pages-and-resources/progress/messages.js
@@ -1,0 +1,33 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  heading: {
+    id: 'course-authoring.pages-resources.progress.heading',
+    defaultMessage: 'Configure progress',
+  },
+  enableProgressLabel: {
+    id: 'course-authoring.pages-resources.progress.enable-progress.label',
+    defaultMessage: 'Progress',
+  },
+  enableProgressHelp: {
+    id: 'course-authoring.pages-resources.progress.enable-progress.help',
+    defaultMessage: `As students work through graded assignments, scores
+        will appear under the progress tab. The progress tab contains a chart of
+        all graded assignments in the course, with a list of all assignments and
+        scores below.`,
+  },
+  enableProgressLink: {
+    id: 'course-authoring.pages-resources.progress.enable-progress.link',
+    defaultMessage: 'Learn more about progress',
+  },
+  enableGraphLabel: {
+    id: 'course-authoring.pages-resources.progress.enable-graph.label',
+    defaultMessage: 'Enable progress graph',
+  },
+  enableGraphHelp: {
+    id: 'course-authoring.pages-resources.progress.enable-graph.help',
+    defaultMessage: 'If enabled, students can view the progress graph',
+  },
+});
+
+export default messages;

--- a/src/pages-and-resources/wiki/Settings.jsx
+++ b/src/pages-and-resources/wiki/Settings.jsx
@@ -1,0 +1,49 @@
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import PropTypes from 'prop-types';
+import React from 'react';
+import * as Yup from 'yup';
+
+import FormSwitchGroup from '../../generic/FormSwitchGroup';
+import { useAppSetting } from '../../utils';
+import AppSettingsModal from '../app-settings-modal/AppSettingsModal';
+import messages from './messages';
+
+function WikiSettings({ intl, onClose }) {
+  const [enablePublicWiki, saveSetting] = useAppSetting('allowPublicWikiAccess');
+  const handleSettingsSave = (values) => saveSetting(values.enablePublicWiki);
+
+  return (
+    <AppSettingsModal
+      appId="wiki"
+      title={intl.formatMessage(messages.heading)}
+      enableAppHelp={intl.formatMessage(messages.enableWikiHelp)}
+      enableAppLabel={intl.formatMessage(messages.enableWikiLabel)}
+      learnMoreText={intl.formatMessage(messages.enableWikiLink)}
+      onClose={onClose}
+      initialValues={{ enablePublicWiki }}
+      validationSchema={{ enablePublicWiki: Yup.boolean() }}
+      onSettingsSave={handleSettingsSave}
+    >
+      {
+        ({ values, handleChange, handleBlur }) => (
+          <FormSwitchGroup
+            id="enable-public-wiki"
+            name="enablePublicWiki"
+            label={intl.formatMessage(messages.enablePublicWikiLabel)}
+            helpText={intl.formatMessage(messages.enablePublicWikiHelp)}
+            onChange={handleChange}
+            onBlue={handleBlur}
+            checked={values.enablePublicWiki}
+          />
+        )
+      }
+    </AppSettingsModal>
+  );
+}
+
+WikiSettings.propTypes = {
+  intl: intlShape.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default injectIntl(WikiSettings);

--- a/src/pages-and-resources/wiki/messages.js
+++ b/src/pages-and-resources/wiki/messages.js
@@ -1,0 +1,34 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  heading: {
+    id: 'course-authoring.pages-resources.wiki.heading',
+    defaultMessage: 'Configure wiki',
+  },
+  enableWikiLabel: {
+    id: 'course-authoring.pages-resources.wiki.enable-wiki.label',
+    defaultMessage: 'Wiki',
+  },
+  enableWikiHelp: {
+    id: 'course-authoring.pages-resources.wiki.enable-wiki.help',
+    defaultMessage: `The course wiki can be set up based on the needs of your
+    course. Common uses might include sharing answers to course FAQs, sharing
+    editable course information, or providing access to learner-created
+    resources.`,
+  },
+  enableWikiLink: {
+    id: 'course-authoring.pages-resources.wiki.enable-wiki.link',
+    defaultMessage: 'Learn more about the wiki',
+  },
+  enablePublicWikiLabel: {
+    id: 'course-authoring.pages-resources.wiki.enable-public-wiki.label',
+    defaultMessage: 'Enable public wiki access',
+  },
+  enablePublicWikiHelp: {
+    id: 'course-authoring.pages-resources.wiki.enable-public-wiki.help',
+    defaultMessage: `If enabled, edX users can view the course wiki even when
+    they're not enrolled in the course.`,
+  },
+});
+
+export default messages;


### PR DESCRIPTION
This PR adds config forms for edxnotes, progress and wiki.

**JIRA tickets**: TNL-8101, TNL-8451, TNL-8452, TNL-8455

**Dependencies**: None

**Screenshots**: 

https://user-images.githubusercontent.com/118837/129155397-dcc8bb84-1db1-4338-a4fa-1d640ab00af2.mp4

![Wiki settings](https://user-images.githubusercontent.com/118837/129156161-368e412c-8f52-4b82-aceb-efadaed32b66.png)

Wiki settings

**Merge deadline**: None

**Testing instructions**:

The changes in this PR are currently visual only, and non-functional, so they mainly need to be compared with the mockups. 

(Note: wiki is currently not marked as configurable, but you can trigger its dialog here: http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/pages-and-resources/wiki/settings)

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD
