### PR TITLE
[BD-38][TNL-8339] feat: Use `messages` field from API

### DIFF
--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -56,6 +56,9 @@ function LtiConfigForm({
       <Form ref={formRef} onSubmit={handleSubmit}>
         <h3 className="mb-3">{title}</h3>
         <p>{intl.formatMessage(messages.formInstructions)}</p>
+        {app.messages && app.messages.map(msg => (
+          <p key={msg}>{msg}</p>
+        ))}
         <Form.Group controlId="consumerKey" isInvalid={isInvalidConsumerKey} className="mb-4">
           <Form.Control
             floatingLabel={intl.formatMessage(messages.consumerKey)}
@@ -111,6 +114,7 @@ LtiConfigForm.propTypes = {
       accessibility: PropTypes.string,
       contactEmail: PropTypes.string,
     }).isRequired,
+    messages: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   appConfig: PropTypes.shape({
     consumerKey: PropTypes.string,

--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -46,6 +46,7 @@ function normalizePluginConfig(data) {
 function normalizeApps(data) {
   const apps = Object.entries(data.providers.available).map(([key, app]) => ({
     id: key,
+    messages: app.messages,
     featureIds: app.features,
     // TODO: Fix this and get it from the backend!
     externalLinks: {

--- a/src/pages-and-resources/discussions/data/redux.test.js
+++ b/src/pages-and-resources/discussions/data/redux.test.js
@@ -51,6 +51,7 @@ const legacyApp = {
     contactEmail: '',
   },
   hasFullSupport: false,
+  messages: [],
 };
 
 const piazzaApp = {
@@ -69,6 +70,7 @@ const piazzaApp = {
     contactEmail: '',
   },
   hasFullSupport: true,
+  messages: [],
 };
 
 let axiosMock;

--- a/src/pages-and-resources/discussions/factories/mockApiResponses.js
+++ b/src/pages-and-resources/discussions/factories/mockApiResponses.js
@@ -31,6 +31,7 @@ export const piazzaApiResponse = {
           accessibility: '',
           contact_email: '',
         },
+        messages: [],
       },
       piazza: {
         features: [
@@ -47,6 +48,7 @@ export const piazzaApiResponse = {
           accessibility: '',
           contact_email: '',
         },
+        messages: [],
       },
     },
   },
@@ -98,6 +100,7 @@ export const legacyApiResponse = {
           accessibility: '',
           contact_email: '',
         },
+        messages: [],
       },
       piazza: {
         features: [
@@ -114,6 +117,7 @@ export const legacyApiResponse = {
           accessibility: '',
           contact_email: '',
         },
+        messages: [],
       },
     },
   },


### PR DESCRIPTION
When fetching details for discussion providers from the API,
the `messages` field is used if available and
displayed in the configuration page for each provider.

The `messages` field is introduced in edx/edx-platform#28092

Related tickets:
* [TNL-8339](https://openedx.atlassian.net/browse/TNL-8339)
* [BB-4249 (OpenCraft Internal)](https://tasks.opencraft.com/browse/BB-4249)

# Testing

Using a backend that includes edx/edx-platform#28092:
1. Open the discussion settings for a course
2. Select Discourse (the only provider with messages at the time of writing)
3. Verify that the config form displays the message "Discourse requires that LTI advanced sharing be enabled for your course, as this provider uses email address and username to personalize the experience. Please contact support@edx.org to enable this feature"