### PR TITLE
[BD-38][TNL-8438] Replace settings button with link for non-supported apps with legacy links

### DIFF
--- a/src/pages-and-resources/PagesAndResources.jsx
+++ b/src/pages-and-resources/PagesAndResources.jsx
@@ -36,6 +36,7 @@ function PagesAndResources({ courseId, intl }) {
   if (loadingStatus === RequestStatus.IN_PROGRESS) {
     return <></>;
   }
+
   return (
     <PagesAndResourcesProvider courseId={courseId}>
       <main className="container container-mw-md">

--- a/src/pages-and-resources/pages/PageCard.jsx
+++ b/src/pages-and-resources/pages/PageCard.jsx
@@ -1,9 +1,9 @@
 import { history } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import {
-  Card, Icon, IconButton, Badge,
+  Badge, Card, Icon, IconButton, Hyperlink,
 } from '@edx/paragon';
-import { Settings } from '@edx/paragon/icons';
+import { ArrowForward, Settings } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import messages from '../messages';
@@ -28,6 +28,31 @@ function PageCard({
 }) {
   const { path: pagesAndResourcesPath } = useContext(PagesAndResourcesContext);
 
+  const SettingsButton = () => {
+    if (page.legacyLink) {
+      return (
+        <Hyperlink destination={page.legacyLink}>
+          <Icon
+            className="mb-0 mr-1"
+            src={ArrowForward}
+            size="inline"
+            screenReaderText={intl.formatMessage(messages.settings)}
+          />
+        </Hyperlink>
+      );
+    }
+    return (page.allowedOperations.configure || page.allowedOperations.enable) && (
+      <IconButton
+        className="mb-0 mr-1"
+        src={Settings}
+        iconAs={Icon}
+        size="inline"
+        alt={intl.formatMessage(messages.settings)}
+        onClick={() => history.push(`${pagesAndResourcesPath}/${page.id}/settings`)}
+      />
+    );
+  };
+
   return (
     <Card
       className="shadow card"
@@ -37,29 +62,18 @@ function PageCard({
       }}
     >
       <Card.Body className="d-flex flex-column justify-content-between">
-        <div>
-          <Card.Title className="d-flex mb-0 align-items-center justify-content-between">
-            <h4 className="m-0 p-0">{page.name}</h4>
-            {(page.allowedOperations.configure || page.allowedOperations.enable)
-          && (
-            <IconButton
-              className="mb-0 mr-1"
-              src={Settings}
-              iconAs={Icon}
-              size="inline"
-              alt={intl.formatMessage(messages.settings)}
-              onClick={() => history.push(`${pagesAndResourcesPath}/${page.id}/settings`)}
-            />
-          )}
-          </Card.Title>
-          {
-            page.enabled && (
-              <Badge className="py-1" variant="success">
-                {intl.formatMessage(messages.enabled)}
-              </Badge>
-            )
-          }
-        </div>
+        <Card.Title className="d-flex mb-0 align-items-center justify-content-between">
+          <h4 className="m-0 p-0">{page.name}</h4>
+          <SettingsButton />
+        </Card.Title>
+
+        {
+          page.enabled && (
+            <Badge className="py-1" variant="success">
+              {intl.formatMessage(messages.enabled)}
+            </Badge>
+          )
+        }
 
         <Card.Text className="m-0">
           {page.description}


### PR DESCRIPTION
# Description

If an app has a legacy link and has no explicit support in the MFE,
a link is now rendered instead of the settings button.

After marking the `calculator` and `discussion` apps as supported, and running the backend with the changes in edx/edx-platform#28098, the page grid now looks like this:

![image](https://user-images.githubusercontent.com/3984777/126894448-c7bede82-7d23-451d-834a-669d1c4ddfe3.png)

Related tickets:
* [TNL-8438](https://openedx.atlassian.net/browse/TNL-8438)
* [BB-4416 (OpenCraft Internal)](https://tasks.opencraft.com/browse/BB-4416)

# Testing

Using the backend changes in edx/edx-platform#28098:

1. Open the pages and resources page for the demo course
2. Verify that:
  1. the settings button appears for "supported" apps (e.g. `calculator` and `discussion`)
  2. the link to studio appear for non-supported apps with legacy links (e.g. `texbooks`)
  3. Nothing appears for non-supported apps without legacy links (e.g. `teams`)