### PR TITLE
fix: remove padding from badges to stay consistent with Paragon badges design.

### DIFF
--- a/src/generic/status-badge/StatusBadge.jsx
+++ b/src/generic/status-badge/StatusBadge.jsx
@@ -10,8 +10,8 @@ function StatusBadge({ intl, status, label }) {
     <>
       {label && `${label} `}
       {status
-        ? <Badge className="py-1" variant="success">{intl.formatMessage(messages.enabled)}</Badge>
-        : <Badge className="py-1" variant="secondary">{intl.formatMessage(messages.disabled)}</Badge>}
+        ? <Badge variant="success">{intl.formatMessage(messages.enabled)}</Badge>
+        : <Badge variant="secondary">{intl.formatMessage(messages.disabled)}</Badge>}
     </>
   );
 }


### PR DESCRIPTION
### [TNL-8481](https://openedx.atlassian.net/browse/TNL-8481)

### Description
Fix the badges within `frontend-app-course-authoring` to be consistent with Paragon badges.

#### Paragon Badges
https://paragon-edx.netlify.app/components/badge/

#### Before
![Screen Shot 2021-07-12 at 7 27 22 PM](https://user-images.githubusercontent.com/30112155/125306033-47ff5b80-e348-11eb-941a-9bc5bd586026.png)

#### After
![Screen Shot 2021-07-12 at 7 27 10 PM](https://user-images.githubusercontent.com/30112155/125306025-46ce2e80-e348-11eb-9009-aa5a4568618e.png)