### PR TITLE
feat: Get learn more links from the backend instead of hard-coding it in the frontend [BD-38] [TNL-8446] [BB-4462]

### DIFF
--- a/src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx
+++ b/src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx
@@ -59,7 +59,6 @@ function AppSettingsModal({
   onSettingsSave,
   enableAppLabel,
   enableAppHelp,
-  learnMoreURL,
   learnMoreText,
 }) {
   const { courseId } = useContext(PagesAndResourcesContext);
@@ -86,10 +85,10 @@ function AppSettingsModal({
     }
   };
 
-  const learnMoreLink = (
+  const learnMoreLink = appInfo.documentationLinks?.learnMoreConfiguration && (
     <Hyperlink
       className="text-primary-500"
-      destination={learnMoreURL}
+      destination={appInfo.documentationLinks.learnMoreConfiguration}
       target="_blank"
       rel="noreferrer noopener"
     >
@@ -210,7 +209,6 @@ AppSettingsModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   enableAppLabel: PropTypes.string.isRequired,
   enableAppHelp: PropTypes.string.isRequired,
-  learnMoreURL: PropTypes.string.isRequired,
   learnMoreText: PropTypes.string.isRequired,
 };
 

--- a/src/pages-and-resources/calculator/Settings.jsx
+++ b/src/pages-and-resources/calculator/Settings.jsx
@@ -1,4 +1,3 @@
-import { getConfig } from '@edx/frontend-platform';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -6,18 +5,14 @@ import AppSettingsModal from '../app-settings-modal/AppSettingsModal';
 
 import messages from './messages';
 
-const CALCULATOR_HELP_URL = getConfig().CALCULATOR_HELP_URL
-  || 'https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/exercises_tools/calculator.html';
-
 function CalculatorSettings({ intl, onClose }) {
   return (
     <AppSettingsModal
       appId="calculator"
       title={intl.formatMessage(messages.heading)}
-      enableAppHelp={intl.formatMessage(messages.enableProgressHelp)}
-      enableAppLabel={intl.formatMessage(messages.enableProgressLabel)}
-      learnMoreText={intl.formatMessage(messages.enableProgressLink)}
-      learnMoreURL={CALCULATOR_HELP_URL}
+      enableAppHelp={intl.formatMessage(messages.enableCalculatorHelp)}
+      enableAppLabel={intl.formatMessage(messages.enableCalculatorLabel)}
+      learnMoreText={intl.formatMessage(messages.enableCalculatorLink)}
       onClose={onClose}
     />
   );

--- a/src/pages-and-resources/calculator/messages.js
+++ b/src/pages-and-resources/calculator/messages.js
@@ -5,17 +5,17 @@ const messages = defineMessages({
     id: 'course-authoring.pages-resources.calculator.heading',
     defaultMessage: 'Configure calculator',
   },
-  enableProgressLabel: {
+  enableCalculatorLabel: {
     id: 'course-authoring.pages-resources.calculator.enable-calculator.label',
     defaultMessage: 'Calculator',
   },
-  enableProgressHelp: {
+  enableCalculatorHelp: {
     id: 'course-authoring.pages-resources.calculator.enable-calculator.help',
     defaultMessage: `The calculator supports numbers, operators, constants,
       functions, and other mathematical concepts. When enabled, an icon to
       access the calculator appears on all pages in the body of your course.`,
   },
-  enableProgressLink: {
+  enableCalculatorLink: {
     id: 'course-authoring.pages-resources.calculator.enable-calculator.link',
     defaultMessage: 'Learn more about the calculator',
   },


### PR DESCRIPTION
This updates the app settings page to use a link returned by the backend instead of using a hard-coded link in the frontend.

**JIRA tickets**: TNL-8446

**Dependencies**: https://github.com/edx/edx-platform/pull/28327

**Screenshots**: Always include screenshots if there is any change to the UI.

**Merge deadline**: "None" 

**Testing instructions**:

1. Test the associated edx-platform change: https://github.com/edx/edx-platform/pull/28327
2. Check that the URL in the calendar app matches the url returned by the API
3. Try changing the edx-platform help url for calendar and see that it's updated in the frontend

**Reviewers**
- [ ] (OpenCraft internal reviewer's GitHub username goes here)
- [ ] edX reviewer[s] TBD