### PR TITLE
fix: Change textbooks card arrow icon to iconButton

### DIFF
--- a/src/pages-and-resources/pages/PageCard.jsx
+++ b/src/pages-and-resources/pages/PageCard.jsx
@@ -36,11 +36,12 @@ function PageCard({
     if (page.legacyLink) {
       return (
         <Hyperlink destination={page.legacyLink}>
-          <Icon
+          <IconButton
             className="mb-0 mr-1"
             src={ArrowForward}
+            iconAs={Icon}
             size="inline"
-            screenReaderText={intl.formatMessage(messages.settings)}
+            alt={intl.formatMessage(messages.settings)}
           />
         </Hyperlink>
       );


### PR DESCRIPTION
Update textbooks card arrow icon to iconButton with perfect hover colour 

<img width="322" alt="Screenshot 2021-08-04 at 9 30 39 PM" src="https://user-images.githubusercontent.com/79941147/128218973-2d8f8b67-7c7f-4430-a89d-f37ddf282367.png">
