### PR TITLE
Fix teams app config to make it configurable [BD-38] [BB-4868] [TNL-8702]

### DIFF
--- a/src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx
+++ b/src/pages-and-resources/app-settings-modal/AppSettingsModal.jsx
@@ -117,6 +117,7 @@ function AppSettingsModal({
   onSettingsSave,
   enableAppLabel,
   enableAppHelp,
+  configureAppHelp,
   learnMoreText,
 }) {
   const { courseId } = useContext(PagesAndResourcesContext);
@@ -207,29 +208,37 @@ function AppSettingsModal({
                   {intl.formatMessage(messages.errorSavingMessage)}
                 </Alert>
               )}
-              <FormSwitchGroup
-                id={`enable-${appId}-toggle`}
-                name="enabled"
-                onChange={(event) => formikProps.handleChange(event)}
-                onBlur={formikProps.handleBlur}
-                checked={formikProps.values.enabled}
-                label={(
-                  <div className="d-flex align-items-center">
-                    {enableAppLabel}
-                    {formikProps.values.enabled && (
-                      <Badge className="ml-2" variant="success">
-                        {intl.formatMessage(messages.enabled)}
-                      </Badge>
-                    )}
-                  </div>
-                )}
-                helpText={(
+              { (configureBeforeEnable && !formikProps.values.enabled)
+                ? (
                   <div>
-                    <p>{enableAppHelp}</p>
-                    <span className="py-3">{learnMoreLink}</span>
+                    <p>{configureAppHelp}</p>
                   </div>
+                )
+                : (
+                  <FormSwitchGroup
+                    id={`enable-${appId}-toggle`}
+                    name="enabled"
+                    onChange={(event) => formikProps.handleChange(event)}
+                    onBlur={formikProps.handleBlur}
+                    checked={formikProps.values.enabled}
+                    label={(
+                      <div className="d-flex align-items-center">
+                        {enableAppLabel}
+                        {formikProps.values.enabled && (
+                        <Badge className="ml-2" variant="success">
+                          {intl.formatMessage(messages.enabled)}
+                        </Badge>
+                        )}
+                      </div>
                 )}
-              />
+                    helpText={(
+                      <div>
+                        <p>{enableAppHelp}</p>
+                        <span className="py-3">{learnMoreLink}</span>
+                      </div>
+                )}
+                  />
+                )}
               {(formikProps.values.enabled || configureBeforeEnable) && children
               && <AppConfigFormDivider marginAdj={{ default: 0, sm: 0 }} />}
               <AppSettingsForm formikProps={formikProps} showForm={formikProps.values.enabled || configureBeforeEnable}>
@@ -270,6 +279,7 @@ AppSettingsModal.propTypes = {
   onClose: PropTypes.func.isRequired,
   enableAppLabel: PropTypes.string.isRequired,
   enableAppHelp: PropTypes.string.isRequired,
+  configureAppHelp: PropTypes.string,
   learnMoreText: PropTypes.string.isRequired,
   configureBeforeEnable: PropTypes.bool,
 };
@@ -280,6 +290,7 @@ AppSettingsModal.defaultProps = {
   initialValues: {},
   validationSchema: {},
   configureBeforeEnable: false,
+  configureAppHelp: null,
 };
 
 export default injectIntl(AppSettingsModal);

--- a/src/pages-and-resources/teams/Settings.jsx
+++ b/src/pages-and-resources/teams/Settings.jsx
@@ -49,6 +49,7 @@ function TeamSettings({
       appId="teams"
       title={intl.formatMessage(messages.heading)}
       enableAppHelp={intl.formatMessage(messages.enableTeamsHelp)}
+      configureAppHelp={intl.formatMessage(messages.configureTeamsHelp)}
       enableAppLabel={intl.formatMessage(messages.enableTeamsLabel)}
       learnMoreText={intl.formatMessage(messages.enableTeamsLink)}
       onClose={onClose}

--- a/src/pages-and-resources/teams/messages.js
+++ b/src/pages-and-resources/teams/messages.js
@@ -15,7 +15,7 @@ const messages = defineMessages({
   },
   configureTeamsHelp: {
     id: 'authoring.pagesAndResources.teams.configureTeams.help',
-    defaultMessage: 'This app cannot be enabled or disabled the regular way',
+    defaultMessage: 'This app needs to be configured before it can be enabled',
   },
   enableTeamsLink: {
     id: 'authoring.pagesAndResources.teams.enableTeams.link',

--- a/src/pages-and-resources/teams/messages.js
+++ b/src/pages-and-resources/teams/messages.js
@@ -13,6 +13,10 @@ const messages = defineMessages({
     id: 'authoring.pagesAndResources.teams.enableTeams.help',
     defaultMessage: 'Create team-sets to allow learners to work in small groups on specific projects of activities.',
   },
+  configureTeamsHelp: {
+    id: 'authoring.pagesAndResources.teams.configureTeams.help',
+    defaultMessage: 'This app cannot be enabled or disabled the regular way',
+  },
   enableTeamsLink: {
     id: 'authoring.pagesAndResources.teams.enableTeams.link',
     defaultMessage: 'Learn more about teams',


### PR DESCRIPTION
## Description

This PR aims to update the Teams Course App plugin to allow enabling only if it is configured. 

## Supporting Information 

[BB-4868](https://tasks.opencraft.com/browse/BB-4868)
[TNL-8702](https://openedx.atlassian.net/browse/TNL-8702)

## Testing Instructions

- Checkout to this branch `tinumide/fix_wiki_teams_apps_config` in the `frontend-app-course-authoring` repository
- For a course that doesn't have teams configured, visit http://localhost:2001/course/course-v1:edX+DemoX+Demo_Course/pages-and-resources/teams/settings
- Click on the Teams App to add a new team set
- Check that the teams app cannot be enabled
- Check that a message is displayed to show that the Teams app cannot be enabled/disabled the regular way