### PR TITLE
fix: display only supported features in mobile view

### DIFF
--- a/src/pages-and-resources/discussions/app-list/FeatureList.test.jsx
+++ b/src/pages-and-resources/discussions/app-list/FeatureList.test.jsx
@@ -48,10 +48,12 @@ describe('FeaturesList', () => {
     const button = getByRole(container, 'button');
     userEvent.click(button);
     features.forEach((feature) => {
-      const featureNodes = queryAllByText(
-        container, messages[`featureName-${feature.id}`].defaultMessage,
-      );
-      expect(featureNodes.map(node => node.closest('div'))).toHaveLength(1);
+      if (app.featureIds.includes(feature.id)) {
+        const featureNodes = queryAllByText(
+          container, messages[`featureName-${feature.id}`].defaultMessage,
+        );
+        expect(featureNodes.map(node => node.closest('div'))).toHaveLength(1);
+      }
     });
   });
 
@@ -62,17 +64,6 @@ describe('FeaturesList', () => {
       const featureElement = queryByText(container, messages[`featureName-${feature.id}`].defaultMessage);
       if (app.featureIds.includes(feature.id)) {
         expect(featureElement.querySelector('svg')).toHaveAttribute('id', 'check-icon');
-      }
-    });
-  });
-
-  test('A dash icon is shown with each unsupported feature', () => {
-    const button = getByRole(container, 'button');
-    userEvent.click(button);
-    features.forEach((feature) => {
-      const featureElement = queryByText(container, messages[`featureName-${feature.id}`].defaultMessage);
-      if (!app.featureIds.includes(feature.id)) {
-        expect(featureElement.querySelector('svg')).toHaveAttribute('id', 'remove-icon');
       }
     });
   });

--- a/src/pages-and-resources/discussions/app-list/FeatureList.test.jsx
+++ b/src/pages-and-resources/discussions/app-list/FeatureList.test.jsx
@@ -14,12 +14,6 @@ describe('FeaturesList', () => {
     hasFullSupport: false,
     id: 'legacy',
   };
-  const features = [
-    { id: 'basic-configuration' },
-    { id: 'wcag-2.1' },
-    { id: 'discussion-page' },
-    { id: 'embedded-course-sections' },
-  ];
   let container;
 
   beforeEach(() => {
@@ -27,7 +21,6 @@ describe('FeaturesList', () => {
       <IntlProvider locale="en">
         <FeaturesList
           app={app}
-          features={features}
         />
       </IntlProvider>,
     );
@@ -47,24 +40,20 @@ describe('FeaturesList', () => {
   test('displays a row for each available feature', () => {
     const button = getByRole(container, 'button');
     userEvent.click(button);
-    features.forEach((feature) => {
-      if (app.featureIds.includes(feature.id)) {
-        const featureNodes = queryAllByText(
-          container, messages[`featureName-${feature.id}`].defaultMessage,
-        );
-        expect(featureNodes.map(node => node.closest('div'))).toHaveLength(1);
-      }
+    app.featureIds.forEach((id) => {
+      const featureNodes = queryAllByText(
+        container, messages[`featureName-${id}`].defaultMessage,
+      );
+      expect(featureNodes.map(node => node.closest('div'))).toHaveLength(1);
     });
   });
 
   test('A check icon is shown with each supported feature', () => {
     const button = getByRole(container, 'button');
     userEvent.click(button);
-    features.forEach((feature) => {
-      const featureElement = queryByText(container, messages[`featureName-${feature.id}`].defaultMessage);
-      if (app.featureIds.includes(feature.id)) {
-        expect(featureElement.querySelector('svg')).toHaveAttribute('id', 'check-icon');
-      }
+    app.featureIds.forEach((id) => {
+      const featureElement = queryByText(container, messages[`featureName-${id}`].defaultMessage);
+      expect(featureElement.querySelector('svg')).toHaveAttribute('id', 'check-icon');
     });
   });
 });

--- a/src/pages-and-resources/discussions/app-list/FeaturesList.jsx
+++ b/src/pages-and-resources/discussions/app-list/FeaturesList.jsx
@@ -1,19 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Remove, Check } from '@edx/paragon/icons';
+import { Check } from '@edx/paragon/icons';
 import { Collapsible } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
 import messages from './messages';
 
-const SupportedFeature = (
-  <span className="mr-3">
-    <Check id="check-icon" className="text-success-500" />
-  </span>
-);
-const NonSupportedFeature = (
-  <span className="mr-3">
-    <Remove id="remove-icon" className="text-light-700" />
-  </span>
+const SupportedFeature = (featureName) => (
+  <>
+    <span className="mr-3">
+      <Check id="check-icon" className="text-success-500" />
+    </span>
+    {featureName}
+  </>
 );
 
 function FeaturesList({ app, features, intl }) {
@@ -34,10 +32,9 @@ function FeaturesList({ app, features, intl }) {
     >
       {features && features.map((feature) => (
         <div key={`collapsible-${app.id}&${feature.id}`} className="d-flex mb-1">
-          {app.featureIds.includes(feature.id)
-            ? SupportedFeature
-            : NonSupportedFeature}
-          {intl.formatMessage(messages[`featureName-${feature.id}`])}
+          {app.featureIds.includes(feature.id) && (
+            SupportedFeature(intl.formatMessage(messages[`featureName-${feature.id}`]))
+          )}
         </div>
       ))}
     </Collapsible>

--- a/src/pages-and-resources/discussions/app-list/FeaturesList.jsx
+++ b/src/pages-and-resources/discussions/app-list/FeaturesList.jsx
@@ -1,20 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Check } from '@edx/paragon/icons';
 import { Collapsible } from '@edx/paragon';
 import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+
+import SupportedFeature from './SupportedFeature';
 import messages from './messages';
 
-const SupportedFeature = (featureName) => (
-  <>
-    <span className="mr-3">
-      <Check id="check-icon" className="text-success-500" />
-    </span>
-    {featureName}
-  </>
-);
-
-function FeaturesList({ app, features, intl }) {
+function FeaturesList({ app, intl }) {
   return (
     <Collapsible
       onClick={(event) => event.stopPropagation()}
@@ -30,11 +22,9 @@ function FeaturesList({ app, features, intl }) {
       )}
       styling="basic"
     >
-      {features && features.map((feature) => (
-        <div key={`collapsible-${app.id}&${feature.id}`} className="d-flex mb-1">
-          {app.featureIds.includes(feature.id) && (
-            SupportedFeature(intl.formatMessage(messages[`featureName-${feature.id}`]))
-          )}
+      {app.featureIds.map((id) => (
+        <div key={`collapsible-${app.id}&${id}`} className="d-flex mb-1">
+          <SupportedFeature name={intl.formatMessage(messages[`featureName-${id}`])} />
         </div>
       ))}
     </Collapsible>
@@ -48,6 +38,5 @@ FeaturesList.propTypes = {
     id: PropTypes.string.isRequired,
     featureIds: PropTypes.array.isRequired,
   }).isRequired,
-  features: PropTypes.arrayOf(PropTypes.object).isRequired,
   intl: intlShape.isRequired,
 };

--- a/src/pages-and-resources/discussions/app-list/SupportedFeature.jsx
+++ b/src/pages-and-resources/discussions/app-list/SupportedFeature.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Check } from '@edx/paragon/icons';
+
+const SupportedFeature = ({ name }) => (
+  <>
+    <span className="mr-3">
+      <Check id="check-icon" className="text-success-500" />
+    </span>
+    {name}
+  </>
+);
+
+SupportedFeature.propTypes = {
+  name: PropTypes.string.isRequired,
+};
+
+export default SupportedFeature;

--- a/src/pages-and-resources/discussions/app-list/SupportedFeature.test.jsx
+++ b/src/pages-and-resources/discussions/app-list/SupportedFeature.test.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, queryByText } from '@testing-library/react';
+
+import SupportedFeature from './SupportedFeature';
+import messages from './messages';
+
+describe('SupportedFeature', () => {
+  const name = messages['featureName-basic-configuration'].defaultMessage;
+  let container;
+
+  beforeEach(() => {
+    const wrapper = render(
+      <SupportedFeature
+        name={name}
+      />,
+    );
+    container = wrapper.container;
+  });
+
+  test('displays a check icon ', () => {
+    expect(container.querySelector('svg')).toHaveAttribute('id', 'check-icon');
+  });
+
+  test('displays feature name', () => {
+    expect(queryByText(container, name)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
[TNL-8092](https://openedx.atlassian.net/browse/TNL-8092)

FeatureList Component Only renders in mobile view.
- Update responsive provider selection UI "features" layout
- Display only supported features in collapse card on mobile view
- Hide feature tables in mobile view

<img width="342" alt="Screenshot 2021-11-08 at 1 18 32 PM" src="https://user-images.githubusercontent.com/79941147/140708124-a975b55e-2442-41b4-a74c-aacd329f0550.png">
