### PR TITLE
fix: undefined key fixed in case of empty lti configs

### DIFF
--- a/src/pages-and-resources/discussions/data/api.js
+++ b/src/pages-and-resources/discussions/data/api.js
@@ -94,7 +94,8 @@ function normalizeAppConfig(data) {
       ...normalizeLtiConfig(data.lti_configuration),
     };
   }
-  return [legacyConfig, ltiConfig, piiConfig];
+  if (!_.isEmpty(ltiConfig)) { return [legacyConfig, ltiConfig, piiConfig]; }
+  return [legacyConfig, piiConfig];
 }
 
 function normalizeDiscussionTopic(data) {


### PR DESCRIPTION
fix: undefined key fixed in case of empty lti configs 
