### PR TITLE
UI update for warnings and messages

### DIFF
--- a/src/pages-and-resources/discussions/DiscussionsSettings.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.jsx
@@ -121,7 +121,6 @@ function DiscussionsSettings({ courseId, intl }) {
               eventKey={SELECTION_STEP}
               title={intl.formatMessage(messages.providerSelection)}
             >
-              <AppList />
               {
                 !canChangeProviders && (
                   <Alert variant="warning">
@@ -129,6 +128,7 @@ function DiscussionsSettings({ courseId, intl }) {
                   </Alert>
                 )
               }
+              <AppList />
             </Stepper.Step>
             <Stepper.Step
               eventKey={SETTINGS_STEP}

--- a/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
+++ b/src/pages-and-resources/discussions/app-config-form/apps/lti/LtiConfigForm.jsx
@@ -64,22 +64,21 @@ function LtiConfigForm({ onSubmit, intl, formRef }) {
       <Form ref={formRef} onSubmit={handleSubmit}>
         <h3 className="mb-3">{providerName}</h3>
         <p>
-          {showLTIConfig ? (
-            intl.formatMessage(messages.formInstructions)
-          ) : (
-            <FormattedMessage
-              {...messages.adminOnlyConfig}
-              values={{
-                providerName,
-                platformName: getConfig().SITE_NAME,
-                supportEmail: supportEmail ? (
-                  <MailtoLink to={supportEmail}>{supportEmail}</MailtoLink>
-                ) : (
-                  'support'
-                ),
-              }}
-            />
-          )}
+          <FormattedMessage
+            {...messages.adminOnlyConfig}
+            values={{
+              providerName,
+              platformName: getConfig().SITE_NAME,
+              supportEmail: supportEmail ? (
+                <MailtoLink to={supportEmail}>{supportEmail}</MailtoLink>
+              ) : (
+                'support'
+              ),
+            }}
+          />
+        </p>
+        <p>
+          {showLTIConfig && intl.formatMessage(messages.formInstructions)}
         </p>
         {app.ltiMessages && app.ltiMessages.map((msg) => <p key={msg}>{msg}</p>)}
         {showLTIConfig && (


### PR DESCRIPTION
https://openedx.atlassian.net/browse/TNL-9416

in LTI course discussion configuration different form Instructions messages were shown for admin and other accounts. So to align form instructions messages for every type of accounts. The admin will now be shown the following messages attached in the screenshot.
The experience for others will remain same as before

<img width="1437" alt="Screenshot 2021-12-17 at 1 55 09 AM" src="https://user-images.githubusercontent.com/67791278/146447760-5a8f80b2-1395-409c-ad54-ee590e7e3636.png">

view for non admin accounts
<img width="1440" alt="Screenshot 2021-12-17 at 12 03 21 PM" src="https://user-images.githubusercontent.com/67791278/146503330-54d827df-5438-435a-a156-acf32e8dfee1.png">
