### PR TITLE
fix: fixed course detail api params

### DIFF
--- a/src/data/api.js
+++ b/src/data/api.js
@@ -9,9 +9,9 @@ function normalizeCourseDetail(data) {
   };
 }
 
-export async function getCourseDetail(courseId) {
+export async function getCourseDetail(courseId, username) {
   const { data } = await getAuthenticatedHttpClient()
-    .get(`${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${courseId}`);
+    .get(`${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${courseId}?username=${username}`);
 
   return normalizeCourseDetail(data);
 }

--- a/src/data/thunks.js
+++ b/src/data/thunks.js
@@ -15,7 +15,7 @@ export function fetchCourseDetail(courseId) {
     dispatch(updateStatus({ courseId, status: LOADING }));
 
     try {
-      const courseDetail = await getCourseDetail(courseId);
+      const courseDetail = await getCourseDetail(courseId, getAuthenticatedUser().username);
       dispatch(updateStatus({ courseId, status: LOADED }));
 
       dispatch(addModel({ modelType: 'courseDetails', model: courseDetail }));

--- a/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
+++ b/src/pages-and-resources/discussions/DiscussionsSettings.test.jsx
@@ -204,7 +204,7 @@ describe('DiscussionsSettings', () => {
     });
 
     test('requires confirmation if changing provider', async () => {
-      axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${courseId}`).reply(200, courseDetailResponse);
+      axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${courseId}?username=abc123`).reply(200, courseDetailResponse);
       await executeThunk(fetchCourseDetail(courseId), store.dispatch);
       history.push(`/course/${courseId}/pages-and-resources/discussion`);
 
@@ -224,7 +224,7 @@ describe('DiscussionsSettings', () => {
     });
 
     test('can cancel confirmation', async () => {
-      axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${courseId}`).reply(200, courseDetailResponse);
+      axiosMock.onGet(`${getConfig().LMS_BASE_URL}/api/courses/v1/courses/${courseId}?username=abc123`).reply(200, courseDetailResponse);
       await executeThunk(fetchCourseDetail(courseId), store.dispatch);
       history.push(`/course/${courseId}/pages-and-resources/discussion`);
 


### PR DESCRIPTION
[TNL-9420](https://openedx.atlassian.net/browse/TNL-9420)

Added username to the course detail api query params. The username query param is required and if not sent the api assumes that the requesting user is Anonymous